### PR TITLE
Log based metric for checkout service

### DIFF
--- a/.github/workflows/e2e_scripts/cleanup_monitoring.py
+++ b/.github/workflows/e2e_scripts/cleanup_monitoring.py
@@ -15,6 +15,7 @@ import os
 import sys
 
 from google.cloud import monitoring_v3
+from google.cloud import logging_v2
 from google.cloud.monitoring_dashboard import v1
 
 def cleanupDashboards(project_name):
@@ -28,6 +29,18 @@ def cleanupDashboards(project_name):
                 client.delete_dashboard(dashboard.name)
             except:
                 print('Could not delete dashboard: ' + dashboard.name)
+
+def cleanupLogBasedMetrics(project_name):
+    """ Deletes all log-based metrics. """
+    client = logging_v2.MetricsServiceV2Client()
+    metrics = True
+    while metrics:
+        metrics = list(client.list_log_metrics(project_name))
+        for metric in metrics:
+            try:
+                client.delete_log_metric(metric.name)
+            except:
+                print('Could not delete metric: ' + metric.name)
 
 def cleanupPolicies(project_name):
     """ Delete all alerting policies for both uptime checks and SLOs. """
@@ -95,6 +108,7 @@ def cleanupUptimeCheck(project_name):
 def doCleanup(project_name):
     """ Ensures that resources are deleted in the proper order so no exceptions are thrown. """
     cleanupDashboards(project_name)
+    cleanupLogBasedMetrics(project_name)
     cleanupPolicies(project_name)
     cleanupNotificationChannels(project_name)
     cleanupSlos(project_name)

--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -362,7 +362,7 @@ func (cs *checkoutService) prepOrderItems(ctx context.Context, items []*pb.CartI
 		if err != nil {
 			return nil, fmt.Errorf("failed to get product #%q", item.GetProductId())
 		}
-		log.Infof("[CheckoutService] orderedItem=%q", product.Name)
+		log.Infof("orderedItem=%q, id=%q", product.Name, product.Id)
 		price, err := cs.convertCurrency(ctx, product.GetPriceUsd(), userCurrency)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert price of %q to %s", item.GetProductId(), userCurrency)

--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -362,6 +362,7 @@ func (cs *checkoutService) prepOrderItems(ctx context.Context, items []*pb.CartI
 		if err != nil {
 			return nil, fmt.Errorf("failed to get product #%q", item.GetProductId())
 		}
+		// Note: This log line is used in a log-based metric. Changes to the log line will not be compatible with the metric. 
 		log.Infof("orderedItem=%q, id=%q", product.Name, product.Id)
 		price, err := cs.convertCurrency(ctx, product.GetPriceUsd(), userCurrency)
 		if err != nil {

--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -362,6 +362,7 @@ func (cs *checkoutService) prepOrderItems(ctx context.Context, items []*pb.CartI
 		if err != nil {
 			return nil, fmt.Errorf("failed to get product #%q", item.GetProductId())
 		}
+		log.Infof("[CheckoutService] orderedItem=%q", product.Name)
 		price, err := cs.convertCurrency(ctx, product.GetPriceUsd(), userCurrency)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert price of %q to %s", item.GetProductId(), userCurrency)

--- a/terraform/monitoring/06_log_based_metric.tf
+++ b/terraform/monitoring/06_log_based_metric.tf
@@ -1,0 +1,83 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Creates a log-based metric by extracting a specific log written by the Checkout Service. 
+# The log being used for metric is from the Checkout Service and has the format:
+# [CheckoutService] orderedItem="Vintage Typewriter"
+#
+# The label and Regex extractor is used to create filters on the metric
+# This resource creates only the metric
+resource "google_logging_metric" "checkoutservice_logging_metric" {
+  name   = "checkoutservice_custom_metric"
+  filter = "resource.type=k8s_container AND resource.labels.cluster_name=cloud-ops-sandbox AND resource.labels.namespace_name=default AND resource.labels.container_name=server AND [CheckoutService]"
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"  # specifies our metric to be a counter-based metric
+    unit        = "1"
+    labels {
+      key         = "product_name"
+      description = "Filters by Product Name"
+    }
+    display_name = "Ordered Products Metric"
+  }
+  label_extractors = {
+    # Regex extractor has matching group to match the product name. Example: [CheckoutService] orderedItem="Terrarium" matches Terrarium
+    "filter" = "REGEXP_EXTRACT(jsonPayload.message, \"\\\\[CheckoutService\\\\] orderedItem=\\\\\\\"([^\\\"]+)\\\\\\\"\")"
+  }
+}
+
+# Creates a dashboard and chart for the log-based metric defined above.
+# Uses the label to group by the product name
+resource "google_monitoring_dashboard" "log_based_metric_dashboard" {
+	dashboard_json = <<EOF
+{
+  "displayName": "Log Based Metric Dashboard",
+  "gridLayout": {
+    "columns": "2",
+    "widgets": [
+      {
+        "title": "Number of Products Ordered grouped by Product Name",
+        "xyChart": {
+          "dataSets": [
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"logging.googleapis.com/user/${google_logging_metric.checkoutservice_logging_metric.name}\" resource.type=\"k8s_container\"",
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_RATE",
+                    "crossSeriesReducer": "REDUCE_MEAN",
+                    "groupByFields": [
+                      "metric.label.\"product_name\""
+                    ]
+                  }
+                }
+              },
+              "plotType": "LINE",
+              "minAlignmentPeriod": "60s"
+            }
+          ],
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          },
+          "chartOptions": {
+            "mode": "COLOR"
+          }
+        }
+      }
+    ]
+  }
+}
+EOF
+}

--- a/terraform/monitoring/06_log_based_metric.tf
+++ b/terraform/monitoring/06_log_based_metric.tf
@@ -14,6 +14,7 @@
 
 # Creates a log-based metric by extracting a specific log written by the Checkout Service. 
 # The log being used for the metric is from the Checkout Service and has the format:
+#
 # orderedItem="Vintage Typewriter", id="OLJCESPC7Z"
 #
 # The label and Regex extractor are used to create filters on the metric

--- a/terraform/monitoring/06_log_based_metric.tf
+++ b/terraform/monitoring/06_log_based_metric.tf
@@ -14,7 +14,6 @@
 
 # Creates a log-based metric by extracting a specific log written by the Checkout Service. 
 # The log being used for the metric is from the Checkout Service and has the format:
-#
 # orderedItem="Vintage Typewriter", id="OLJCESPC7Z"
 #
 # The label and Regex extractor are used to create filters on the metric

--- a/tests/monitoring_integration_test.py
+++ b/tests/monitoring_integration_test.py
@@ -24,6 +24,7 @@ import sys
 import json
 
 from google.cloud import monitoring_v3
+from google.cloud import logging_v2
 from google.cloud.monitoring_dashboard import v1
 from googleapiclient import discovery
 from oauth2client.client import GoogleCredentials
@@ -195,6 +196,22 @@ class TestMonitoringDashboard(unittest.TestCase):
 		""" Test that the Product Catalog Service Dashboard gets created. """
 		found_dashboard = self.checkForDashboard('Product Catalog Service Dashboard')
 		self.assertTrue(found_dashboard)
+
+	def testLogBasedMetricDashboard(self):
+		""" Test that the Log Based Metric Dashboard gets created. """
+		found_dashboard = self.checkForDashboard('Log Based Metric Dashboard')
+		self.assertTrue(found_dashboard)
+
+class TestLogBasedMetric(unittest.TestCase):
+	def setUp(self):
+		self.client = logging_v2.MetricsServiceV2Client()
+		self.project_id = getProjectId()
+
+	def testCheckoutServiceLogMetric(self):
+		""" Test that the log based metric for the Checkout Service gets created. """
+		metric_name = self.client.metric_path(self.project_id, "checkoutservice_log_metric")
+		response = self.client.get_log_metric(metric_name)
+		self.assertTrue(response)
 
 class TestCustomService(unittest.TestCase):
 	def setUp(self):


### PR DESCRIPTION
#WHAT: Adds a log line in the CheckoutService that tracks which products are being ordered and then adds a count based log-based metric through Terraform. 

#WHY: Log based metrics is one of the GCP unique features - here we demonstrate how Terraform can be used to provision metrics and dashboards on the metric and a good example of a log-based metric. 

#HOW: Terraform resources for provisioning the metric and then a dashboard to show the metric.

#TESTING: Tests added to the integration test. 

Closes #80 