### PR TITLE
bump nodejs docker images to use v12

### DIFF
--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:8-alpine as base
+FROM node:12-alpine as base
 
 FROM base as builder
 

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:8-alpine as base
+FROM node:12-alpine as base
 
 FROM base as builder
 


### PR DESCRIPTION
This resolves #327 by eliminating the error. It also makes the docker images compatible with the debugger dependency upgrade that renovate bot has suggested.

More details:
- Confirmed that the docker image still builds and our dependencies still install fine.
- Confirmed that the opentelemetry tracing still works.
- To be clear: the profiler no longer errors, but the services currencyservice and paymentservice do not show up on the Cloud Profiler page. I looked as far back as I could (30 days) and it doesn't look like they ever have. I don't have a clear idea of why this is the case.
- This allows us to update @google-cloud/debug-agent.