### PR TITLE
Increase Googler auth timeout

### DIFF
--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -301,7 +301,7 @@ checkAuthentication() {
         log "Authentication failed"
         log "Please allow gcloud and Cloud Shell to access your GCP account"
     fi
-    while [[ -z $AUTH_ACCT  && "${TRIES}" -lt 30  ]]; do
+    while [[ -z $AUTH_ACCT  && "${TRIES}" -lt 300  ]]; do
         AUTH_ACCT=$(gcloud auth list --format="value(account)")
         sleep 1;
         TRIES=$((TRIES + 1))


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/367

Now waits for 5 minutes instead of 30 seconds