### PR TITLE
Find old projects in destroy.sh

### DIFF
--- a/terraform/destroy.sh
+++ b/terraform/destroy.sh
@@ -29,9 +29,13 @@ SCRIPT_DIR=$(realpath $(dirname "$0"))
 cd $SCRIPT_DIR
 
 # find the cloud operations sandbox project id
-found=$(gcloud projects list \
-          --filter="(id:cloud-ops-sandbox-* AND name='Cloud Operations Sandbox Demo') OR (id:stackdriver-sandbox-* AND name='Stackdriver Sandbox Demo')" \
-          --format="value(projectId)")
+filter=$(cat <<-END
+  (id:cloud-ops-sandbox-* AND name='Cloud Operations Sandbox Demo')
+  OR
+  (id:stackdriver-sandbox-* AND name='Stackdriver Sandbox Demo')
+END
+)
+found=$(gcloud projects list --filter="$filter" --format="value(projectId)")
 
 # find projects owned by current user
 for proj in ${found[@]}; do


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/364

- Improves destroy.sh to show legacy `stackdriver-sandbox` projects
- also added some enhancements to make it work more like install.sh (only show owned projects, show creation date)