### PR TITLE
Release updates readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Cloud Operations Sandbox (Alpha)
 
-![Continuous Integration](https://github.com/GoogleCloudPlatform/stackdriver-sandbox/workflows/Continuous%20Integration/badge.svg)
+![Continuous Integration](https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/workflows/Continuous%20Integration/badge.svg)
 
 Cloud Operations Sandbox is an open-source tool that helps practitioners to learn Service Reliability Engineering practices from Google and apply them on their cloud services using [Ops Management](https://cloud.google.com/products/operations) (formerly Stackdriver).
 It is based on [Hipster Shop](https://github.com/GoogleCloudPlatform/microservices-demo), a cloud-native microservices application.
@@ -41,7 +41,7 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 
 Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
 
-[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/stackdriver-sandbox.git&cloudshell_git_branch=v0.2.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.0)
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.2.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.0)
 
 __Note__: If installation stops due to billing account errors, set up the billing account, and then in the `terraform/` diretory of the project created in Cloud Shell command prompt, type: `./install.sh`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,14 +49,14 @@
         <li><b>Load Generator</b> - a component that produces synthetic traffic on a demo service</li>
         <li><b>(Soon) SRE Runbook</b> - for operating deployed sample service that follows best SRE practices</li>
       </ul>
-      <a class="github-btn" href="https://github.com/GoogleCloudPlatform/stackdriver-sandbox" target="_blank">View source code</a>
+      <a class="github-btn" href="https://github.com/GoogleCloudPlatform/cloud-ops-sandbox" target="_blank">View source code</a>
     </section>
     <section class="cta">
       <h2>Get started now</h2>
       <div class="steps">
         <div class="step step-1">
           <!--label>Step 1</label-->
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/stackdriver-sandbox.git&cloudshell_git_branch=v0.2.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.0" target="_blank" onclick="metrics.recordCustomTime('stackdriver-demo-open-in-cloud-shell')">Open in Google Cloud Shell</a>
+          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.2.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.0" target="_blank" onclick="metrics.recordCustomTime('stackdriver-demo-open-in-cloud-shell')">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
       </div>
@@ -66,7 +66,7 @@
       <div class="steps">
         <div class="step step-2">
           <label>Follow along with our User Guide.</label>
-	  <a class="github-btn" href="https://github.com/GoogleCloudPlatform/stackdriver-sandbox/blob/master/docs/README.md">View on GitHub</a>
+	  <a class="github-btn" href="https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/blob/master/docs/README.md">View on GitHub</a>
 	</div>
       </div>
     </section>

--- a/make-release.sh
+++ b/make-release.sh
@@ -30,6 +30,10 @@ fi
 # temporarily pin manifests to :$NEW_VERSION
 find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s/:latest/:${NEW_VERSION}/g" {} \;
 
+# update README
+sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/README.md;
+sed -i -e "s/cloudshell-image:v\([0-9\.]\+\)/cloudshell-image:${NEW_VERSION}/g" ${REPO_ROOT}/README.md;
+
 # update website deployment tag
 sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/docs/index.html;
 sed -i -e "s/cloudshell-image:v\([0-9\.]\+\)/cloudshell-image:${NEW_VERSION}/g" ${REPO_ROOT}/docs/index.html;


### PR DESCRIPTION
The automated release script currently does not update the Open in Cloud Shell button on the README. This PR fixes that

I also updated the repo url on the README and website