### PR TITLE
remove existing load generator when using old projects

### DIFF
--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -298,6 +298,11 @@ displaySuccessMessage() {
     log "     Google Cloud Console Monitoring Workspace: $gcp_monitoring_path"
     log "     Hipstershop web app address: http://$external_ip"
     log "     Load generator web interface: $loadgen_addr"
+    log ""
+    log "To remove the Sandbox once finished using it, run"
+    log ""
+    log "     ./destroy.sh"
+    log ""
     log "********************************************************************************"
 }
 

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -257,7 +257,7 @@ loadGen() {
   old_loadgen=$(gcloud compute instances list --project $project_id --filter="name:loadgenerator*" --format="value(name)")
   if [[ -n "$old_loadgen" ]]; then
     loadgen_zone=$(gcloud compute instances list --project $project_id --filter="name:loadgenerator*" --format="value(zone)")
-    $(gcloud compute instances delete $old_loadgen --zone $loadgen_zone --quiet)
+    gcloud compute instances delete $old_loadgen --zone $loadgen_zone --quiet
   fi
   # launch a new load generator
   ../loadgenerator/loadgen autostart $external_ip

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -253,6 +253,13 @@ getExternalIp() {
 # Install Load Generator service and start generating synthetic traffic to Sandbox
 loadGen() {
   log "Running load generator"
+  # remove existing load generator
+  old_loadgen=$(gcloud compute instances list --project $project_id --filter="name:loadgenerator*" --format="value(name)")
+  if [[ -n "$old_loadgen" ]]; then
+    loadgen_zone=$(gcloud compute instances list --project $project_id --filter="name:loadgenerator*" --format="value(zone)")
+    $(gcloud compute instances delete $old_loadgen --zone $loadgen_zone --quiet)
+  fi
+  # launch a new load generator
   ../loadgenerator/loadgen autostart $external_ip
   # find the IP of the load generator web interface
   TRIES=0


### PR DESCRIPTION
1. Remove existing load generator when using old projects.
Fixes #378, #11.
2. Display cluster removal info in next step.
Fixes #32.