### PR TITLE
bug fix for indefinite service wait

### DIFF
--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -231,7 +231,7 @@ installMonitoring() {
 
   log "Checking to make sure necessary Istio services are ready for monitoring"
   python3 -m pip install google-cloud-monitoring
-  python3 monitoring/istio_service_setup.py $project_id $CLUSTER_ZONE $service-wait
+  python3 monitoring/istio_service_setup.py $project_id $CLUSTER_ZONE $service_wait
   log "Creating monitoring examples (dashboards, uptime checks, alerting policies, etc.)..."
   pushd monitoring/
   terraform init -lock=false

--- a/terraform/monitoring/istio_service_setup.py
+++ b/terraform/monitoring/istio_service_setup.py
@@ -36,11 +36,12 @@ def findService(client, service_name, project_id, zone, should_timeout):
 	full_service_name = getIstioServiceName(service_name, project_id, zone)
 	service = client.service_path(project_id, full_service_name)
 	num_tries = 0
-	while not found_service and (should_timeout and num_tries <= 50):
+	while not found_service and num_tries <= 50:
 		try:
 			found_service = client.get_service(service)
 		except: # possible exceptions include GoogleAPICallError and ValueError
-			num_tries += 1
+			if should_timeout:
+				num_tries += 1
 			time.sleep(6)
 			found_service = False
 


### PR DESCRIPTION
previously the indefinite wait would terminate early because of the condition on the while loop. This should fix it for the E2E test so that it properly waits forever for the services to appear. 