### PR TITLE
Push tagged image

### DIFF
--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -33,6 +33,7 @@ steps:
         if [[ -d "./cloud-shell" ]]; then
             echo "building $$TAG"
             docker build -t gcr.io/$PROJECT_ID/cloudshell-image:$$TAG ./cloud-shell
+            docker push gcr.io/$PROJECT_ID/cloudshell-image:$$TAG
         else
             echo "No cloud-shell directory in tag $$TAG"
         fi


### PR DESCRIPTION
Fixes issue in which images are being rebuilt but not being pushed to Google Container Registry. Both `latest` and `v0.2.0` images were being rebuilt, but `v0.2.0` images were not being pushed to GCR--this was an oversight on my part. I did not include `docker push` in the tagged image logic, which I unfortunately did not detect in the Build logs until this morning because I was looking to make sure the image was being built instead of pushed.

Necessary for Custom Cloud Shell Image certification of versioned images.

I tested the `cloudbuild.yaml` file using the manual Cloud Build trigger in GCP on this branch. The results can be found here: https://pantheon.corp.google.com/cloud-build/builds/08425f1d-854a-4842-b75e-00f64ee1e855?project=stackdriver-sandbox-230822.