### PR TITLE
Fix Cloud Shell GitHub Actions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,12 +8,12 @@ workloads run using [GitHub self-hosted runners](https://help.github.com/en/acti
     - VM should be at least n1-standard-4 with 100GB persistent disk
     - VM should be created with appropriate service account for desired [worker tag](#Tags)
 2. SSH into new VM through Google Cloud Console
-3. Follow the instructions to add a new runner on the [Actions Settings page](https://github.com/GoogleCloudPlatform/stackdriver-sandbox/settings/actions) to authenticate the new runner
+3. Follow the instructions to add a new runner on the [Actions Settings page](https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/settings/actions) to authenticate the new runner
 4. Attach the [appropriate tag(s)](#Tags) to the new runner
 5. Set GitHub Actions as a background service
     - `sudo ~/actions-runner/svc.sh install ; sudo ~/actions-runner/svc.sh start`
 6. Run the following command to install dependencies
-    - `wget -O - https://raw.githubusercontent.com/GoogleCloudPlatform/stackdriver-sandbox/master/.github/workflows/install-dependencies.sh | bash`
+    - `wget -O - https://raw.githubusercontent.com/GoogleCloudPlatform/cloud-ops-sandbox/master/.github/workflows/install-dependencies.sh | bash`
 
 ## Tags
 - `kind-cluster`
@@ -28,7 +28,7 @@ workloads run using [GitHub self-hosted runners](https://help.github.com/en/acti
     - `Cloud Build Editor`
     - `read permissions on GCS bucket holding cloud build logs`
     - `write permissons on GCS bucket holding GCR images`
-  - requires `PROJECT_ID` to be set properly in the [repo's secrets](https://github.com/GoogleCloudPlatform/stackdriver-sandbox/settings/secrets)
+  - requires `PROJECT_ID` to be set properly in the [repo's secrets](https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/settings/secrets)
 - `e2e-worker`
   - end to end test worker
   - requires the following permissions on the end-to-end test project:
@@ -38,7 +38,7 @@ workloads run using [GitHub self-hosted runners](https://help.github.com/en/acti
     - `logging admin`
     - `service account user`
     - `storage admin` access to the GCR and terraform data buckets
-  - requires `E2E_PROJECT_ID` to be set properly in the [repo's secrets](https://github.com/GoogleCloudPlatform/stackdriver-sandbox/settings/secrets)
+  - requires `E2E_PROJECT_ID` to be set properly in the [repo's secrets](https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/settings/secrets)
 
 ---
 ## Workflows

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -95,7 +95,8 @@ workloads run using [GitHub self-hosted runners](https://help.github.com/en/acti
 ### Update-Custom-Image.yaml
 
 #### Triggers
-- on each commit to a test branch: Build-Trigger
+- on each commit to master
+- on each new tag pushed to repo
 - every 24 hours
 
 #### Actions

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,7 +22,12 @@ workloads run using [GitHub self-hosted runners](https://help.github.com/en/acti
     - should have no service account for security reasons
 - `push-privilege`
   - image push worker
-  - requires permissions to push images to GCR storage bucket, and deploy to App Engine
+  - requires the following permissions on the CI test project:
+    - `App Engine Admin`
+    - `Cloud Build Service Account`
+    - `Cloud Build Editor`
+    - `read permissions on GCS bucket holding cloud build logs`
+    - `write permissons on GCS bucket holding GCR images`
   - requires `PROJECT_ID` to be set properly in the [repo's secrets](https://github.com/GoogleCloudPlatform/stackdriver-sandbox/settings/secrets)
 - `e2e-worker`
   - end to end test worker

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -36,18 +36,3 @@ jobs:
                        --tag=latest
       env:
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
-    - name: Push Cloud Shell Image to GCR
-      timeout-minutes: 20
-      run: |
-        set -x
-        gcloud auth configure-docker --quiet
-        # build and tag with git hash
-        IMAGE_SHA=gcr.io/$PROJECT_ID/cloudshell-image:$GITHUB_SHA
-        docker build -t $IMAGE_SHA ./cloud-shell
-        docker push $IMAGE_SHA
-        # build and tag with latest
-        IMAGE_LATEST=gcr.io/$PROJECT_ID/cloudshell-image:latest
-        docker build -t $IMAGE_LATEST ./cloud-shell
-        docker push $IMAGE_LATEST
-      env:
-        PROJECT_ID: ${{ secrets.PROJECT_ID }}

--- a/.github/workflows/push-tags.yml
+++ b/.github/workflows/push-tags.yml
@@ -35,17 +35,6 @@ jobs:
                        --tag=${{ steps.get_version.outputs.VERSION  }}
       env:
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
-    - name: Push Cloud Shell Image to GCR
-      timeout-minutes: 20
-      run: |
-        set -x
-        gcloud auth configure-docker --quiet
-        IMAGE_PATH=gcr.io/$PROJECT_ID/cloudshell-image:${{ steps.get_version.outputs.VERSION }}
-        docker build -t $IMAGE_PATH ./cloud-shell
-        docker push $IMAGE_PATH
-      env:
-        PROJECT_ID: ${{ secrets.PROJECT_ID }}
-
     - name: Deploy Website to App Engine
       timeout-minutes: 20
       run: |

--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Rebuild Latest and Tagged Custom Cloud Shell Images"
+name: "Rebuild Cloud Shell Images"
 on:
   schedule:
     # run daily at midnight
@@ -32,16 +32,23 @@ jobs:
     runs-on: [self-hosted, push-privilege]
     steps:
     - uses: actions/checkout@v2
-    - name: Run Cloud Build Trigger to Rebuild All Tagged Images
+    - name: Run Cloud Build Trigger
+      id: cloud_build
       run: |
         run_info=$(gcloud beta builds triggers run --branch=fix-cloudshell-automation Build-CloudShell-Image)
         run_id=$(echo $run_info | grep -oP "id: \K(\w+-){4}\w+")
-        # attempt log streaming
-        gcloud beta builds log --stream "$run_id"
-        # find completion status
-        STATUS=$(gcloud beta builds describe "$run_id" | grep status | head -n 1 | awk 'NF>1{print $NF}')
+        echo ::set-output name=run_id::${run_id}
+    - name: Display Logs
+      continue-on-error: true
+      run: |
+        gcloud beta builds log --stream ${{ steps.cloud_build.outputs.run_id }}
+    - name: Check Completion Status
+      run: |
+        set -x
+        STATUS="QUEUED"
         while [[ "$STATUS" == "WORKING" || "$STATUS" == "$QUEUED" || "$STATUS" == "STATUS_UNKNOWN" ]]; do
             sleep 5
-            STATUS=$(gcloud beta builds describe "$run_id" | grep status | head -n 1 | awk 'NF>1{print $NF}')
+            STATUS=$(gcloud beta builds describe ${{ steps.cloud_build.outputs.run_id }} \
+                        | grep status | head -n 1 | awk 'NF>1{print $NF}')
         done
         test "$STATUS" = "SUCCESS"

--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -21,7 +21,6 @@ on:
     # run on pushes to master
     branches:
       - master
-      - fix-cloudshell-automation
     # run after pushing new tags
     tags:
       - 'v*'
@@ -35,7 +34,7 @@ jobs:
     - name: Run Cloud Build Trigger
       id: cloud_build
       run: |
-        run_info=$(gcloud beta builds triggers run --branch=fix-cloudshell-automation Build-CloudShell-Image)
+        run_info=$(gcloud beta builds triggers run --branch=master Build-CloudShell-Image)
         run_id=$(echo $run_info | grep -oP "id: \K(\w+-){4}\w+")
         echo ::set-output name=run_id::${run_id}
     - name: Display Logs

--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -15,15 +15,17 @@
 name: "Rebuild Latest and Tagged Custom Cloud Shell Images"
 on:
   schedule:
-  # run daily at midnight
+    # run daily at midnight
     - cron: '0 0 * * *'
   push:
-    # run on pushes to test branch
+    # run on pushes to master
     branches:
-      - build-trigger
+      - master
+    # run after pushing new tags
+    tags:
+      - 'v*'
   workflow_dispatch:
-  # trigger through UI or API
-  
+    # trigger through UI or API
 jobs:
   build-trigger:
     runs-on: [self-hosted, push-privilege]

--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -21,6 +21,7 @@ on:
     # run on pushes to master
     branches:
       - master
+      - fix-cloudshell-automation
     # run after pushing new tags
     tags:
       - 'v*'
@@ -33,4 +34,14 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run Cloud Build Trigger to Rebuild All Tagged Images
       run: |
-        gcloud beta builds triggers run --branch=master Build-CloudShell-Image
+        run_info=$(gcloud beta builds triggers run --branch=fix-cloudshell-automation Build-CloudShell-Image)
+        run_id=$(echo $run_info | grep -oP "id: \K(\w+-){4}\w+")
+        # attempt log streaming
+        gcloud beta builds log --stream "$run_id"
+        # find completion status
+        STATUS=$(gcloud beta builds describe "$run_id" | grep status | head -n 1 | awk 'NF>1{print $NF}')
+        while [[ "$STATUS" == "WORKING" || "$STATUS" == "$QUEUED" || "$STATUS" == "STATUS_UNKNOWN" ]]; do
+            sleep 5
+            STATUS=$(gcloud beta builds describe "$run_id" | grep status | head -n 1 | awk 'NF>1{print $NF}')
+        done
+        test "$STATUS" = "SUCCESS"

--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         set -x
         STATUS="QUEUED"
-        while [[ "$STATUS" == "WORKING" || "$STATUS" == "$QUEUED" || "$STATUS" == "STATUS_UNKNOWN" ]]; do
+        while [[ "$STATUS" == "WORKING" || "$STATUS" == "QUEUED" || "$STATUS" == "STATUS_UNKNOWN" ]]; do
             sleep 5
             STATUS=$(gcloud beta builds describe ${{ steps.cloud_build.outputs.run_id }} \
                         | grep status | head -n 1 | awk 'NF>1{print $NF}')

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -38,3 +38,4 @@ steps:
             echo "No cloud-shell directory in tag $$TAG"
         fi
     done
+logsBucket: 'gs://sandbox-cloud-build-logs'


### PR DESCRIPTION
Addresses https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/394

I realized the other day that our GitHub Actions are writing Cloud Shell images using cached base images, which effectively expire every week. I updated the Actions to use Elena's new Cloud Build trigger instead, which is more robust. I also added some improvements to the GitHub Action that kicks off the Cloud Build. Now, we can see the Cloud Build logs within the GitHub UI, and GitHub will mirror the Cloud Build completion status so we'll know if anything fails

Here's an example run:
https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/actions/runs/227498277