### PR TITLE
Replace smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         set -x
         # wait for status code 200
-        while [[ -z curl -I localhost:3000 | grep 200 ]]; then
+        while [[ -z "$(curl -I localhost:3000 | grep 200)" ]]; do
             sleep 5
         done
         # ping homepage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,6 @@ jobs:
         set -x
         skaffold config set --global local-cluster true
         skaffold run -p local --status-check=false
-    - name: Deploy Load Generator
-      run: |
-        set -x
-        kubectl create deployment loadgenerator \
-          --image=gcr.io/stackdriver-sandbox-230822/sandbox/loadgenerator:latest
-         kubectl set env deployment/loadgenerator FRONTEND_ADDR=frontend:80
     - name: Wait For Pods
       timeout-minutes: 10
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ on:
     branches:    
       - master
       - release/*
-      - remove-smoke-test
   pull_request:
     # run on pull requests targeting master
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
         kubectl wait --for=condition=available --timeout=500s deployment/currencyservice
         kubectl wait --for=condition=available --timeout=500s deployment/emailservice
         kubectl wait --for=condition=available --timeout=500s deployment/frontend
-        kubectl wait --for=condition=available --timeout=500s deployment/loadgenerator
         kubectl wait --for=condition=available --timeout=500s deployment/paymentservice
         kubectl wait --for=condition=available --timeout=500s deployment/productcatalogservice
         kubectl wait --for=condition=available --timeout=500s deployment/recommendationservice

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
     branches:    
       - master
       - release/*
-      - fix-smoke-test
+      - remove-smoke-test
   pull_request:
     # run on pull requests targeting master
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
     branches:    
       - master
       - release/*
+      - fix-smoke-test
   pull_request:
     # run on pull requests targeting master
     branches:
@@ -75,20 +76,25 @@ jobs:
         kubectl wait --for=condition=available --timeout=500s deployment/productcatalogservice
         kubectl wait --for=condition=available --timeout=500s deployment/recommendationservice
         kubectl wait --for=condition=available --timeout=500s deployment/shippingservice
-    - name: Smoke Test
+    - name: Port Forward frontend
+      run: |
+        set -x
+        port_forward() {
+            # get name of frontend pod
+            local frontend_pod=$(kubectl get pods -l=app=frontend -o=jsonpath='{.items[0].metadata.name}')
+            kubectl port-forward $frontend_pod 3000:8080
+        }
+        port_forward &
+    - name: Ping Frontend
       timeout-minutes: 5
       run: |
         set -x
-        # start fresh loadgenerator pod
-        kubectl delete pod -l app=loadgenerator
-        # wait for requests to come in
-        REQUEST_COUNT="0"
-        while [[ "$REQUEST_COUNT"  -lt "100"  ]]; do
+        # wait for status code 200
+        while [[ -z curl -I localhost:3000 | grep 200 ]]; then
             sleep 5
-            REQUEST_COUNT=$(kubectl logs -l app=loadgenerator | grep Total | awk '{print $2}')
         done
-        # ensure there are no errors hitting endpoints
-        ERROR_COUNT=$(kubectl logs -l app=loadgenerator | grep Total | awk '{print $3}' | sed "s/[(][^)]*[)]//g")
-        if [[ "$ERROR_COUNT" -gt "0" ]]; then
-          exit 1
-        fi
+        # ping homepage
+        # should contain "Hipster Shop"
+        curl --show-error --fail localhost:3000 | grep "Hipster Shop"
+        # ping cart page
+        curl --silent --output /dev/null --show-error --fail localhost:3000/cart


### PR DESCRIPTION
We currently have a smoke test that pings the frontend >100 times, and if it sees a single error, it treats it as a failure. This has been flaky for us, often forcing us to re-run the entire CI test

I replaced the flaky smoke test with curl. It will do a simple ping against the home page and `/cart`, and ensures they both return 200. It also checks the homepage for the text `Hipster Shop`, ensuring we're returning meaningful content. This should cover the same error cases as the smoke test in a much simpler and more reliable way