### PR TITLE
Add website alert popup

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>Cloud Ops Sandbox</title>
+  <title>Cloud Operations Sandbox</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" type="text/css" media="screen" href="css/main.css" />
   <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -38,11 +38,11 @@
 
     <section class="title-row">
       <img src="images/logo_stackdriver.svg" class="stackdriver-logo" width="64" alt="Cloud Operations logo">
-      <h1>Cloud Ops Sandbox</h1>
+      <h1>Cloud Operations Sandbox</h1>
       <div class="badge alpha">Alpha</div>
     </section>
     <section class="content">
-      <h3>Cloud Ops Sandbox is an open source tool* that helps practitioners to learn Cloud Operations on GCP. It offers:</h3>
+      <h3>Cloud Operations Sandbox is an open source tool* that helps practitioners to learn Cloud Operations on GCP. It offers:</h3>
       <ul>
         <li><b>Demo Service</b> - an application built using microservices architecture on modern, cloud native stack.</li>
         <li><b>One-click deployment script</b> of the service to Google Cloud Platform</li>
@@ -57,7 +57,7 @@
         <div class="step step-1">
           <!--label>Step 1</label-->
           <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.2.5&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.5"
-             target="_blank" onclick="confirm('Cloud Ops Sandbox will create a new GCP project and will take ~15-20 minutes to complete. Are you sure you want to continue?')">Open in Google Cloud Shell</a>
+             target="_blank" onclick="confirm('Cloud Operations Sandbox will create a new GCP project and will take ~15-20 minutes to complete. Are you sure you want to continue?')">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>Stackdriver Sandbox</title>
+  <title>Cloud Ops Sandbox</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" type="text/css" media="screen" href="css/main.css" />
   <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -37,12 +37,12 @@
   <section class="page">
 
     <section class="title-row">
-      <img src="images/logo_stackdriver.svg" class="stackdriver-logo" width="64" alt="Stackdriver logo">
-      <h1>Stackdriver Sandbox</h1>
+      <img src="images/logo_stackdriver.svg" class="stackdriver-logo" width="64" alt="Cloud Operations logo">
+      <h1>Cloud Ops Sandbox</h1>
       <div class="badge alpha">Alpha</div>
     </section>
     <section class="content">
-      <h3>Stackdriver Sandbox is an open source tool* that helps practitioners to learn Stackdriver. It offers:</h3>
+      <h3>Cloud Ops Sandbox is an open source tool* that helps practitioners to learn Cloud Operations. It offers:</h3>
       <ul>
         <li><b>Demo Service</b> - an application built using microservices architecture on modern, cloud native stack.</li>
         <li><b>One-click deployment script</b> of the service to Google Cloud Platform</li>
@@ -57,7 +57,7 @@
         <div class="step step-1">
           <!--label>Step 1</label-->
           <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.2.5&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.5"
-             target="_blank" onclick="if (confirm('Stackdriver Sandbox will create a new GCP project and will take ~15-20 minutes to complete. Are you sure you want to continue?')) { metrics.recordCustomTime('stackdriver-demo-open-in-cloud-shell');  return true; } else { return false; } ">Open in Google Cloud Shell</a>
+             target="_blank" onclick="confirm('Cloud Ops Sandbox will create a new GCP project and will take ~15-20 minutes to complete. Are you sure you want to continue?')">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
       <div class="badge alpha">Alpha</div>
     </section>
     <section class="content">
-      <h3>Cloud Ops Sandbox is an open source tool* that helps practitioners to learn Cloud Operations. It offers:</h3>
+      <h3>Cloud Ops Sandbox is an open source tool* that helps practitioners to learn Cloud Operations on GCP. It offers:</h3>
       <ul>
         <li><b>Demo Service</b> - an application built using microservices architecture on modern, cloud native stack.</li>
         <li><b>One-click deployment script</b> of the service to Google Cloud Platform</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,7 +56,8 @@
       <div class="steps">
         <div class="step step-1">
           <!--label>Step 1</label-->
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.2.5&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.5" target="_blank" onclick="metrics.recordCustomTime('stackdriver-demo-open-in-cloud-shell')">Open in Google Cloud Shell</a>
+          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.2.5&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.5"
+             target="_blank" onclick="if (confirm('Stackdriver Sandbox will create a new GCP project and will take ~15-20 minutes to complete. Are you sure you want to continue?')) { metrics.recordCustomTime('stackdriver-demo-open-in-cloud-shell');  return true; } else { return false; } ">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,7 +57,7 @@
         <div class="step step-1">
           <!--label>Step 1</label-->
           <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.2.5&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.5"
-             target="_blank" onclick="confirm('Cloud Operations Sandbox will create a new GCP project and will take ~15-20 minutes to complete. Are you sure you want to continue?')">Open in Google Cloud Shell</a>
+             target="_blank" onclick="return confirm('Cloud Operations Sandbox will create a new GCP project and will take ~15-20 minutes to complete. Are you sure you want to continue?')">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
       </div>

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -152,6 +152,14 @@ createProject() {
     # create project
     if [[ $acct == *"google.com"* ]];
     then
+
+      # TODO: remove after resolving issue
+      log "Due to changes in /experimental-gke folder policy,"
+      log "Google.com accounts are currently not supported by Stackdriver Sandbox.";
+      log "We hope to restore functionality soon."
+      log "b/166170813"
+      exit;
+
       log ""
       log "Note: your project will be created in the /experimental-gke folder."
       log "If you don't have access to this folder, please make sure to request at:"
@@ -375,17 +383,6 @@ parseArguments() {
 
 # check for command line arguments
 parseArguments $*;
-
-# TODO: remove after resolving issue
-acct=$(gcloud info --format="value(config.account)")
-if [[ $acct == *"google.com"*  ]];
-then
-    log "Due to changes in /experimental-gke folder policy,"
-    log "Google.com accounts are currently not supported by Stackdriver Sandbox.";
-    log "We hope to restore functionality soon."
-    log "b/166170813"
-    exit;
-fi;
 
 # ensure gcloud and cloudshell are authenticated
 checkAuthentication;

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -154,10 +154,15 @@ createProject() {
     then
 
       # TODO: remove after resolving issue
-      log "Due to changes in /experimental-gke folder policy,"
-      log "Google.com accounts are currently not supported by Stackdriver Sandbox.";
-      log "We hope to restore functionality soon."
-      log "b/166170813"
+      YELLOW=`tput setaf 3`
+      log ""
+      log ""
+      log "${YELLOW}********************************************************************************"
+      log "${YELLOW}Error:"
+      log "${YELLOW}Due to changes in /experimental-gke folder policy,"
+      log "${YELLOW}Google.com accounts are currently not supported by Stackdriver Sandbox.";
+      log "${YELLOW}We hope to restore functionality soon."
+      log "${YELLOW}b/166170813"
       exit;
 
       log ""

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -158,11 +158,11 @@ createProject() {
       log ""
       log ""
       log "${YELLOW}********************************************************************************"
-      log "${YELLOW}Error:"
-      log "${YELLOW}Due to changes in /experimental-gke folder policy,"
+      log "${YELLOW}⚠️ Due to changes in /experimental-gke folder policy,"
       log "${YELLOW}Google.com accounts are currently not supported by Stackdriver Sandbox.";
       log "${YELLOW}We hope to restore functionality soon."
       log "${YELLOW}b/166170813"
+      log ""
       exit;
 
       log ""

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -153,7 +153,7 @@ createProject() {
     if [[ $acct == *"google.com"* ]];
     then
 
-      # TODO: remove after resolving issue
+      # TODO: remove after resolving b/166170813
       YELLOW=`tput setaf 3`
       log ""
       log ""

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -376,6 +376,17 @@ parseArguments() {
 # check for command line arguments
 parseArguments $*;
 
+# TODO: remove after resolving issue
+acct=$(gcloud info --format="value(config.account)")
+if [[ $acct == *"google.com"*  ]];
+then
+    log "Due to changes in /experimental-gke folder policy,"
+    log "Google.com accounts are currently not supported by Stackdriver Sandbox.";
+    log "We hope to restore functionality soon."
+    log "b/166170813"
+    exit;
+fi;
+
 # ensure gcloud and cloudshell are authenticated
 checkAuthentication;
 

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -152,19 +152,6 @@ createProject() {
     # create project
     if [[ $acct == *"google.com"* ]];
     then
-
-      # TODO: remove after resolving b/166170813
-      YELLOW=`tput setaf 3`
-      log ""
-      log ""
-      log "${YELLOW}********************************************************************************"
-      log "${YELLOW}⚠️ Due to changes in /experimental-gke folder policy,"
-      log "${YELLOW}Google.com accounts are currently not supported by Stackdriver Sandbox.";
-      log "${YELLOW}We hope to restore functionality soon."
-      log "${YELLOW}b/166170813"
-      log ""
-      exit;
-
       log ""
       log "Note: your project will be created in the /experimental-gke folder."
       log "If you don't have access to this folder, please make sure to request at:"


### PR DESCRIPTION
~~I added a new warning for internal users that the Sandbox is currently working for Googler accounts. [Test link](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/Daniel-Sanche/stackdriver-sandbox.git&cloudshell_git_branch=googler-error-msg&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.5)~~ (edit: Googler accounts are re-enabled)

I also added a warning pop-up to the website, warning users that it will take 15-20 mins to provision the project. That can be tested with

```
cd ./docs
python3 -m http.server 8081
```