### PR TITLE
Create googlers sandboxes in a new folder

### DIFF
--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -153,9 +153,9 @@ createProject() {
     if [[ $acct == *"google.com"* ]];
     then
       log ""
-      log "Note: your project will be created in the /experimental-gke folder."
+      log "Note: your project will be created in the /untrusted/demos/cloud-ops-sandboxes folder."
       log "If you don't have access to this folder, please make sure to request at:"
-      log "go/experimental-folder-access"
+      log "go/cloud-ops-sandbox-access"
       log ""
       select opt in "continue" "cancel"; do
         if [[ "$opt" == "continue" ]]; then
@@ -164,7 +164,7 @@ createProject() {
           exit 0;
         fi
       done
-      folder_id="262044416022" # /experimental-gke  
+      folder_id="470827991545" # /cloud-ops-sandboxes  
       gcloud projects create "$project_id" --name="Cloud Operations Sandbox Demo" --folder="$folder_id"    
     else
       gcloud projects create "$project_id" --name="Cloud Operations Sandbox Demo"      


### PR DESCRIPTION
Sandbox creation using google.com accounts stopped working about a week ago due to policy changes.
In this change we are changing the procedure for Googlers: they will have all the Sandboxes created under `/untrusted/demos/cloud-ops-sandboxes` folder and request access via go/cloud-ops-sandbox-access

Fixes #392,#369

Testing: create a Sandbox from google.com account by following [this link](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=FixGooglersSandboxCreation&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.5)