### PR TITLE
Pass GOOGLE_APPLICATION_CREDENTIALS to Python microservices as secret env variable

### DIFF
--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -26,9 +26,19 @@ spec:
         app: emailservice
     spec:
       terminationGracePeriodSeconds: 5
+      volumes:
+      - name: google-cloud-key
+        secret:
+          secretName: my-key
       containers:
       - name: server
         image: gcr.io/stackdriver-sandbox-230822/sandbox/emailservice:latest
+        volumeMounts:
+        - name: google-cloud-key
+          mountPath: /var/secrets/google
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/secrets/google/key.json
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -26,13 +26,16 @@ spec:
         app: emailservice
     spec:
       terminationGracePeriodSeconds: 5
+      # Pod specifies what volumes to provide for this pod
       volumes:
       - name: google-cloud-key
         secret:
-          secretName: my-key
+          secretName: service-key
+          optional: true
       containers:
       - name: server
         image: gcr.io/stackdriver-sandbox-230822/sandbox/emailservice:latest
+        # Where to mount storage inside of the container
         volumeMounts:
         - name: google-cloud-key
           mountPath: /var/secrets/google

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -29,7 +29,8 @@ spec:
       volumes:
       - name: google-cloud-key
         secret:
-          secretName: my-key
+          secretName: service-key
+          optional: true
       containers:
       - name: server
         image: gcr.io/stackdriver-sandbox-230822/sandbox/recommendationservice:latest

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -26,9 +26,16 @@ spec:
         app: recommendationservice
     spec:
       terminationGracePeriodSeconds: 5
+      volumes:
+      - name: google-cloud-key
+        secret:
+          secretName: my-key
       containers:
       - name: server
         image: gcr.io/stackdriver-sandbox-230822/sandbox/recommendationservice:latest
+        volumeMounts:
+        - name: google-cloud-key
+          mountPath: /var/secrets/google
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -42,6 +49,8 @@ spec:
         env:
         - name: PRODUCT_CATALOG_SERVICE_ADDR
           value: "productcatalogservice:3550"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/secrets/google/key.json
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Solves #372 DefaultCredentialsError where python services cant autodetect GOOGLE_APPLICATION_CREDENTIALS, needed by tracing exporter. 

Implements [suggestion 3](https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform):
1. During cluster provisioning, we retrieve GKE’s default services key
2. Pass key.json into K8S cluster as a secret (recommended)
3. Python microservices (email & recommendation) now recognize GOOGLE_APPLICATION_CREDENTIALS as an environment variable 

CMIIW, the part that tripped me up a bit is that `cloudtracespanexporter` expects Google credentials, not just Project_id. My understanding of the original bug is that the Python exporter doesn't detect default credentials, [when we expect it to](https://cloud.google.com/docs/authentication/production). 