### PR TITLE
[loadgen] Remove southamerica-east-1 from regions, replace with us-west-1 regions

### DIFF
--- a/terraform/loadgen/00_loadgen.tf
+++ b/terraform/loadgen/00_loadgen.tf
@@ -18,7 +18,7 @@
 # zone at random - all different regions from where we provisioned
 # the Hipster Shop.
 resource "random_shuffle" "zone" {
-  input = ["us-west1-a", "asia-east1-a", "europe-west2-a", "southamerica-east1-a"]
+  input = ["us-west1-a", "us-west1-b", "us-west1-c", "asia-east1-a", "europe-west2-a"]
 
   # Seeding the RNG is technically optional but while building this we
   # found that it returned the same zone every time unless we seeded it. Here


### PR DESCRIPTION
@nicklin37 alerted me that the latest run of the e2e tests shows that trying to provision a cluster in the `southamerica-east1-a` region failed. There's likely some setting that we need to manually toggle on but for now I think it's best to not try to use it.

exact error:
```
random_shuffle.zone: Creating...
random_shuffle.zone: Creation complete after 0s [id=-]
google_container_cluster.gke_loadgen: Creating...
null_resource.current_project (local-exec): Updated property [core/project].
null_resource.current_project: Creation complete after 1s [id=5712226751518038775]

Error: googleapi: Error 404: Not found: project "***" does not have an auto-mode subnetwork for network "default" in region "southamerica-east1"., notFound

  on 00_loadgen.tf line 43, in resource "google_container_cluster" "gke_loadgen":
  43: resource "google_container_cluster" "gke_loadgen" {
```

