### PR TITLE
Fix reattaching to existing projects

### DIFF
--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Clean Project State
+      timeout-minutes: 30
       run: |
         # clean GCP resources
         .github/workflows/e2e_scripts/clean.sh
@@ -49,6 +50,7 @@ jobs:
         find "./kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s#$OLD_PATH#$NEW_PATH#g" {} \;
         find "./kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s#:latest#:$GITHUB_SHA#g" {} \;
     - name: Run Install Script
+      timeout-minutes: 30
       run: |
         set -x
         # build cloud shell image
@@ -65,6 +67,7 @@ jobs:
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Run Provisioning Test
+      timeout-minutes: 30
       run: |
         set -x
         # get cluster zones
@@ -82,6 +85,7 @@ jobs:
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID }}
     - name: Test Using Existing Project
+      timeout-minutes: 30
       run: |
         set -x
         # get cluster zones
@@ -97,6 +101,7 @@ jobs:
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID }}
     - name: Run Monitoring Integration Tests
+      timeout-minutes: 30
       run: |
         set -x
         # install dependencies
@@ -110,6 +115,7 @@ jobs:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Clean Project State
       if: ${{ always()  }}
+      timeout-minutes: 30
       run: |
         # clean GCP resources
         .github/workflows/e2e_scripts/clean.sh

--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -81,6 +81,21 @@ jobs:
           test-provisioning:$GITHUB_SHA
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID }}
+    - name: Test Using Existing Project
+      run: |
+        set -x
+        # get cluster zones
+        CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project $PROJECT_ID --format="value(zone)")
+        LOADGEN_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox-loadgenerator" --project $PROJECT_ID --format="value(zone)")
+        # run provisioning tests
+        docker run --rm \
+          -e GOOGLE_CLOUD_PROJECT=$PROJECT_ID \
+          -e ZONE=$CLUSTER_ZONE \
+          -e LOADGEN_ZONE=$LOADGEN_ZONE \
+          -v ~/.config:/root/.config \
+          test-provisioning:$GITHUB_SHA
+      env:
+        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID }}
     - name: Run Monitoring Integration Tests
       run: |
         set -x

--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -66,6 +66,21 @@ jobs:
           test-cloud-shell:$GITHUB_SHA
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
+    - name: Test Using Existing Project
+      timeout-minutes: 30
+      run: |
+        set -x
+        # run install script
+        docker run --rm \
+          -e project_id=$PROJECT_ID \
+          -e skip_workspace_prompt=1 \
+          -e service_wait=1 \
+          -v ~/.config:/root/.config \
+          -v `pwd`:/sandbox-shared \
+          --entrypoint /sandbox-shared/.github/workflows/e2e_scripts/run_install.sh \
+          test-cloud-shell:$GITHUB_SHA
+      env:
+        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Run Provisioning Test
       timeout-minutes: 30
       run: |
@@ -75,22 +90,6 @@ jobs:
         LOADGEN_ZONE=$(gcloud container clusters list --filter="name:loadgenerator" --project $PROJECT_ID --format="value(zone)")
         # build provisioning test image
         docker build -t test-provisioning:$GITHUB_SHA tests/provisioning/.
-        # run provisioning tests
-        docker run --rm \
-          -e GOOGLE_CLOUD_PROJECT=$PROJECT_ID \
-          -e ZONE=$CLUSTER_ZONE \
-          -e LOADGEN_ZONE=$LOADGEN_ZONE \
-          -v ~/.config:/root/.config \
-          test-provisioning:$GITHUB_SHA
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID }}
-    - name: Test Using Existing Project
-      timeout-minutes: 30
-      run: |
-        set -x
-        # get cluster zones
-        CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project $PROJECT_ID --format="value(zone)")
-        LOADGEN_ZONE=$(gcloud container clusters list --filter="name:loadgenerator" --project $PROJECT_ID --format="value(zone)")
         # run provisioning tests
         docker run --rm \
           -e GOOGLE_CLOUD_PROJECT=$PROJECT_ID \

--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -69,7 +69,7 @@ jobs:
         set -x
         # get cluster zones
         CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project $PROJECT_ID --format="value(zone)")
-        LOADGEN_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox-loadgenerator" --project $PROJECT_ID --format="value(zone)")
+        LOADGEN_ZONE=$(gcloud container clusters list --filter="name:loadgenerator" --project $PROJECT_ID --format="value(zone)")
         # build provisioning test image
         docker build -t test-provisioning:$GITHUB_SHA tests/provisioning/.
         # run provisioning tests
@@ -86,7 +86,7 @@ jobs:
         set -x
         # get cluster zones
         CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project $PROJECT_ID --format="value(zone)")
-        LOADGEN_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox-loadgenerator" --project $PROJECT_ID --format="value(zone)")
+        LOADGEN_ZONE=$(gcloud container clusters list --filter="name:loadgenerator" --project $PROJECT_ID --format="value(zone)")
         # run provisioning tests
         docker run --rm \
           -e GOOGLE_CLOUD_PROJECT=$PROJECT_ID \

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -29,10 +29,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Clean Project State
+      timeout-minutes: 30
       run: |
         # clean GCP resources
         .github/workflows/e2e_scripts/clean.sh
     - name: Extract Website Values
+      timeout-minutes: 30
       id: website_variables
       run: |
         set -x
@@ -46,6 +48,7 @@ jobs:
         CLOUDSHELL_IMAGE=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_image\=).*?(?=")')
         echo ::set-output name=cloudshell_image::${CLOUDSHELL_IMAGE}
     - name: Run Install Script
+      timeout-minutes: 30
       run: |
         set -x
         # run install script
@@ -62,6 +65,7 @@ jobs:
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name:  Test Using Existing Project
+      timeout-minutes: 30
       run: |
         set -x
         # run install script
@@ -78,12 +82,14 @@ jobs:
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Checkout Release Code
+      timeout-minutes: 30
       run: |
         set -x
         git clone ${{ steps.website_variables.outputs.repo  }} ./release-code
         cd ./release-code
         git checkout ${{ steps.website_variables.outputs.branch }}
     - name: Run Provisioning Test
+      timeout-minutes: 30
       run: |
         set -x
         # get cluster zone
@@ -99,6 +105,7 @@ jobs:
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID }}
     - name: Run Monitoring Integration Tests
+      timeout-minutes: 30
       run: |
         set -x
         # install dependencies
@@ -111,6 +118,7 @@ jobs:
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Clean Project State
+      timeout-minutes: 30
       if: ${{ always()  }}
       run: |
         # clean GCP resources

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -77,19 +77,25 @@ jobs:
           ${{ steps.website_variables.outputs.cloudshell_image }}
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
+    - name: Checkout Release Code
+      run: |
+        set -x
+        git clone ${{ steps.website_variables.outputs.repo  }} ./release-code
+        cd ./release-code
+        git checkout ${{ steps.website_variables.outputs.branch }}
     - name: Run Provisioning Test
       run: |
         set -x
         # get cluster zone
         CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project $PROJECT_ID --format="value(zone)")
         # build provisioning test image
-        docker build -t test-provisioning:$GITHUB_SHA tests/provisioning/.
+        docker build -t test-provisioning:$GITHUB_SHA-release tests/provisioning/.
         # run provisioning tests
         docker run --rm \
           -e GOOGLE_CLOUD_PROJECT=$PROJECT_ID \
           -e ZONE=$CLUSTER_ZONE \
           -v ~/.config:/root/.config \
-          test-provisioning:$GITHUB_SHA
+          test-provisioning:$GITHUB_SHA-release
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID }}
     - name: Run Monitoring Integration Tests

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -92,6 +92,8 @@ jobs:
       timeout-minutes: 30
       run: |
         set -x
+        # change to previous release code state
+        cd ./release-code
         # get cluster zone
         CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project $PROJECT_ID --format="value(zone)")
         # build provisioning test image
@@ -108,6 +110,8 @@ jobs:
       timeout-minutes: 30
       run: |
         set -x
+        # change to previous release code state
+        cd ./release-code
         # install dependencies
         python3 -m pip install -r tests/requirements.txt
         # authenticate cluster

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -38,7 +38,7 @@ jobs:
       id: website_variables
       run: |
         set -x
-        BTN_CONTENT=$(curl https://stackdriver-sandbox.dev/ | grep console-btn)
+        BTN_CONTENT=$(curl https://cloud-ops-sandbox.dev/ | grep console-btn)
         REPO=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_git_repo\=).*?(?=&)')
         echo ::set-output name=repo::${REPO}
         BRANCH=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_git_branch\=).*?(?=&)')

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -20,7 +20,7 @@ on:
   push:
     # run on pushes to test branch
     branches:
-      - e2e-test-release
+      - e2e*
   workflow_dispatch:
     # trigger through UI or API
 jobs:
@@ -46,6 +46,22 @@ jobs:
         CLOUDSHELL_IMAGE=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_image\=).*?(?=")')
         echo ::set-output name=cloudshell_image::${CLOUDSHELL_IMAGE}
     - name: Run Install Script
+      run: |
+        set -x
+        # run install script
+        docker run --rm \
+          -e project_id=$PROJECT_ID \
+          -e skip_workspace_prompt=1 \
+          -e release_repo=${{ steps.website_variables.outputs.repo }} \
+          -e release_branch=${{ steps.website_variables.outputs.branch }} \
+          -e release_dir=${{ steps.website_variables.outputs.dir }} \
+          -v ~/.config:/root/.config \
+          -v `pwd`:/sandbox-shared \
+          --entrypoint /sandbox-shared/.github/workflows/e2e_scripts/run_install.sh \
+          ${{ steps.website_variables.outputs.cloudshell_image }}
+      env:
+        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
+    - name:  Test Using Existing Project
       run: |
         set -x
         # run install script

--- a/.github/workflows/e2e_scripts/clean.sh
+++ b/.github/workflows/e2e_scripts/clean.sh
@@ -41,7 +41,21 @@ while [ -n "$CLUSTER_ZONE" ]; do
 done
 
 
-# delete loadgenerator
+# delete GKE loadgenerator
+LOADGENERATOR_ZONE="first_run"
+while [ -n "$LOADGENERATOR_ZONE" ]; do
+  LOADGENERATOR_ZONE=$(gcloud container clusters list \
+                   --filter="name:loadgenerator" \
+                   --project $PROJECT_ID --format="value(zone)")
+  if [ -n "$LOADGENERATOR_ZONE" ]; then
+      echo "deleting load generator cluster"
+      gcloud container clusters delete loadgenerator \
+          --project $PROJECT_ID --zone $LOADGENERATOR_ZONE --quiet
+      sleep 20
+  fi
+done
+
+# delete legacy GCE loadgenerator
 LOADGENERATOR="first_run"
 while [ -n "$LOADGENERATOR" ]; do
   read -r LOADGENERATOR ZONE <<< $(gcloud compute instances list \

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -277,6 +277,11 @@ loadGen() {
   terraform apply --auto-approve -var="project_id=${project_id}" -var="external_ip=${external_ip}"
   popd
 
+  # authenticate to load generator cluster
+  LOADGEN_ZONE=$(gcloud container clusters list --filter="name:loadgenerator" --project $project_id --format="value(zone)")
+  gcloud container clusters get-credentials loadgenerator --zone "$LOADGEN_ZONE"
+  kubectx loadgenerator=.
+
   LOCUST_PORT="8089"
   # find the IP of the load generator web interface
   TRIES=0
@@ -288,14 +293,9 @@ loadGen() {
      [ -z "$loadgen_ip" ] && sleep 10;
     TRIES=$((TRIES + 1))
   done
-  if [[ -v loadgen_ip ]]; then
-    # Make kubectx alias for this kubectl context
-    kubectx loadgenerator=.
-    # Return kubectl context to the main cluster and show this to the user
-    kubectx main
-    log $(kubectx)
-  fi
-
+  # Return kubectl context to the main cluster and show this to the user
+  kubectx main
+  log $(kubectx)
 }
 
 displaySuccessMessage() {

--- a/terraform/loadgen/00_loadgen.tf
+++ b/terraform/loadgen/00_loadgen.tf
@@ -42,7 +42,7 @@ resource "random_shuffle" "zone" {
 # is possible, check out the docs: https://www.terraform.io/docs/providers/google/r/container_cluster.html
 resource "google_container_cluster" "gke_loadgen" {
   # Here's how you specify the name of the cluster
-  name = "cloud-ops-sandbox-loadgenerator"
+  name = "loadgenerator"
 
   project = var.project_id
 
@@ -76,7 +76,7 @@ resource "google_container_cluster" "gke_loadgen" {
 
       labels = {
         environment = "dev",
-        cluster = "cloud-ops-sandbox-loadgenerator"
+        cluster = "loadgenerator"
       }
     }
 
@@ -110,7 +110,7 @@ resource "null_resource" "current_project" {
 # Setting kubectl context to currently deployed loadgenerator GKE cluster
 resource "null_resource" "set_gke_context" {
   provisioner "local-exec" {
-    command = "gcloud container clusters get-credentials cloud-ops-sandbox-loadgenerator --zone ${element(random_shuffle.zone.result, 0)} --project ${var.project_id}"
+    command = "gcloud container clusters get-credentials loadgenerator --zone ${element(random_shuffle.zone.result, 0)} --project ${var.project_id}"
   }
 
   depends_on = [

--- a/terraform/loadgen/00_loadgen.tf
+++ b/terraform/loadgen/00_loadgen.tf
@@ -76,7 +76,7 @@ resource "google_container_cluster" "gke_loadgen" {
 
       labels = {
         environment = "dev",
-        cluster = "loadgenerator"
+        cluster = "loadgenerator-main"
       }
     }
 

--- a/tests/provisioning/loadgen_test.py
+++ b/tests/provisioning/loadgen_test.py
@@ -28,12 +28,12 @@ class TestLoadGenerator(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Get the location of GKE cluster for later queries"""
-        cls.name = 'projects/{0}/locations/{1}/clusters/cloud-ops-sandbox-loadgenerator'.format(getProjectId(), getClusterZone())
+        cls.name = 'projects/{0}/locations/{1}/clusters/loadgenerator'.format(getProjectId(), getClusterZone())
         # authenticate container cluster
         command=('gcloud config set project {0}'.format(getProjectId()))
         subprocess.run(split(command))
-        # set kubectl context to cloud-ops-sandbox-loadgenerator
-        command=('gcloud container clusters get-credentials cloud-ops-sandbox-loadgenerator --zone {0}'.format(getClusterZone()))
+        # set kubectl context to loadgenerator
+        command=('gcloud container clusters get-credentials loadgenerator --zone {0}'.format(getClusterZone()))
         subprocess.run(split(command))
 
     def testNodeMachineType(self):
@@ -52,7 +52,7 @@ class TestLoadGenerator(unittest.TestCase):
 
     def testReachOfLoadgen(self):
         """Test if querying load generator returns 200"""
-        command = ("kubectl get service locust-main --context=cloud-ops-sandbox-loadgenerator -o jsonpath='{.status.loadBalancer.ingress[0].ip}'")
+        command = ("kubectl get service locust-main --context=loadgenerator -o jsonpath='{.status.loadBalancer.ingress[0].ip}'")
         result = subprocess.run(split(command), encoding='utf-8', capture_output=True)
         loadgen_ip = result.stdout.replace('\n', '')
         url = 'http://{0}:8089'.format(loadgen_ip)


### PR DESCRIPTION
Partially solves https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/444 by renaming the load generator to use a different name prefix

Also:
- add e2e tests so it doesn't happen again
- fixed the clean.sh for the e2e tests so that the load generator cluster is properly cleaned up between runs
- added 30 minute timeout to all e2e tasks in case it gets stuck