### PR TITLE
Add workspace link line break

### DIFF
--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -238,7 +238,8 @@ installMonitoring() {
     log ""
     log "${YELLOW}********************************************************************************"
     log ""
-    log "${YELLOW}⚠️ Please create a monitoring workspace for the project by clicking on the following link: $gcp_monitoring_path"
+    log "${YELLOW}⚠️ Please create a monitoring workspace for the project by clicking on the following link:"
+    log "${YELLOW}  $gcp_monitoring_path"
     log ""
     read -p "${YELLOW}When you are done, please PRESS ENTER TO CONTINUE"
   fi


### PR DESCRIPTION
Fix for a minor issue that was bugging me: sometimes due to window size the workspace creation link would break over multiple lines, and then clicking the link would lead to the wrong GCP project and I'd get a 403. I'd have to resize my browser window and click again for it to work properly

This PR breaks the link out onto its own line to make this issue less likely