### PR TITLE
Fix website deployment

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -36,8 +36,8 @@ sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VE
 sed -i -e "s/cloudshell-image:v\([0-9\.]\+\)/cloudshell-image:${NEW_VERSION}/g" ${REPO_ROOT}/README.md;
 
 # update website deployment tag
-sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/docs/index.html;
-sed -i -e "s/cloudshell-image:v\([0-9\.]\+\)/cloudshell-image:${NEW_VERSION}/g" ${REPO_ROOT}/docs/index.html;
+sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/website/index.html;
+sed -i -e "s/cloudshell-image:v\([0-9\.]\+\)/cloudshell-image:${NEW_VERSION}/g" ${REPO_ROOT}/website/index.html;
 
 # update custom Cloud Shell image variable
 sed -i -e "s/VERSION=v\([0-9\.]\+\)/VERSION=${NEW_VERSION}/g" ${REPO_ROOT}/cloud-shell/Dockerfile;
@@ -56,7 +56,7 @@ else
     git checkout -b "release/${NEW_VERSION}"
     git add "${REPO_ROOT}/kubernetes-manifests/*.yaml"
     git add "${REPO_ROOT}/kubernetes-manifests/loadgenerator/*.yaml"
-    git add "${REPO_ROOT}/docs/index.html"
+    git add "${REPO_ROOT}/website/index.html"
     git add "${REPO_ROOT}/README.md"
     git add "${REPO_ROOT}/cloud-shell/Dockerfile"
     git add "${REPO_ROOT}/terraform/telemetry.py"

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
-# Stackdriver Sandbox Website
+# Cloud Operations Sandbox Website
 
-The Stackdriver Sandbox website is currently deployed at [stackdriver-sandbox.dev](https://stackdriver-sandbox.dev).
+The Stackdriver Sandbox website is currently deployed at [cloud-ops-sandbox.dev](https://cloud-ops-sandbox.dev).
 
 ## Website Architecture
 
@@ -11,7 +11,6 @@ Important files and directories relevent to the website include:
 * `index.html` - located in `website/` directory. This is the main file for the website.
 * `main.css` - located in `website/css/` directory. This is the style sheet for Stackdriver Sandbox's website.
 * `images/` - located in `website/` directory. Any images on the website should be located in this directory.
-* `cloudbuild.yaml` - located in `website/` directory. It is important for this file to be here, since the website is built on App Engine using a build trigger within `stackdriver-sandbox` project on Google Cloud Platform. This build-configuration should be available in order for the website to be automatically deployed.
 
 The website is automatically deployed to App Engine. Every time a new version is released, a build trigger is run that builds the website.
 

--- a/website/index.html
+++ b/website/index.html
@@ -56,8 +56,8 @@
       <div class="steps">
         <div class="step step-1">
           <!--label>Step 1</label-->
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.2.6&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.6"
-             target="_blank" onclick="return confirm('Cloud Operations Sandbox will create a new GCP project and will take ~15-20 minutes to complete. Are you sure you want to continue?')">Open in Google Cloud Shell</a>
+          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.3.0"
+             target="_blank">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
       </div>


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/455
- make-release.sh wasn't changing files in the new website directory. This fixes that automation
- manually updated index.html to point to v0.3.0 release
- removed the pop-up from the website to prevent potential pop-up blockers from breaking our deployment
- updated website README to use cloud operations branding