### PR TITLE
Fix e2e provisioning tests

### DIFF
--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -64,23 +64,6 @@ jobs:
           ${{ steps.website_variables.outputs.cloudshell_image }}
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
-    - name:  Test Using Existing Project
-      timeout-minutes: 30
-      run: |
-        set -x
-        # run install script
-        docker run --rm \
-          -e project_id=$PROJECT_ID \
-          -e skip_workspace_prompt=1 \
-          -e release_repo=${{ steps.website_variables.outputs.repo }} \
-          -e release_branch=${{ steps.website_variables.outputs.branch }} \
-          -e release_dir=${{ steps.website_variables.outputs.dir }} \
-          -v ~/.config:/root/.config \
-          -v `pwd`:/sandbox-shared \
-          --entrypoint /sandbox-shared/.github/workflows/e2e_scripts/run_install.sh \
-          ${{ steps.website_variables.outputs.cloudshell_image }}
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Checkout Release Code
       timeout-minutes: 30
       run: |
@@ -119,6 +102,23 @@ jobs:
         gcloud container clusters get-credentials cloud-ops-sandbox --zone "$CLUSTER_ZONE"
         # run tests
         python3 tests/monitoring_integration_test.py $PROJECT_ID
+      env:
+        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
+    - name:  Test Using Existing Project
+      timeout-minutes: 30
+      run: |
+        set -x
+        # run install script
+        docker run --rm \
+          -e project_id=$PROJECT_ID \
+          -e skip_workspace_prompt=1 \
+          -e release_repo=${{ steps.website_variables.outputs.repo }} \
+          -e release_branch=${{ steps.website_variables.outputs.branch }} \
+          -e release_dir=${{ steps.website_variables.outputs.dir }} \
+          -v ~/.config:/root/.config \
+          -v `pwd`:/sandbox-shared \
+          --entrypoint /sandbox-shared/.github/workflows/e2e_scripts/run_install.sh \
+          ${{ steps.website_variables.outputs.cloudshell_image }}
       env:
         PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Clean Project State

--- a/tests/provisioning/loadgen_test.py
+++ b/tests/provisioning/loadgen_test.py
@@ -35,6 +35,10 @@ class TestLoadGenerator(unittest.TestCase):
         # set kubectl context to loadgenerator
         command=('gcloud container clusters get-credentials loadgenerator --zone {0}'.format(getClusterZone()))
         subprocess.run(split(command))
+        # obtain the context name
+        command=('kubectl config current-context')
+        result = subprocess.run(split(command), encoding='utf-8', capture_output=True)
+        cls.context = result.stdout
 
     def testNodeMachineType(self):
         """Test if the machine type for the nodes is as specified"""
@@ -52,7 +56,7 @@ class TestLoadGenerator(unittest.TestCase):
 
     def testReachOfLoadgen(self):
         """Test if querying load generator returns 200"""
-        command = ("kubectl get service locust-main -o jsonpath='{.status.loadBalancer.ingress[0].ip}'")
+        command = (f"kubectl get service locust-main --context=%s -o jsonpath='\{.status.loadBalancer.ingress[0].ip\}'" % TestLoadGenerator.context)
         result = subprocess.run(split(command), encoding='utf-8', capture_output=True)
         loadgen_ip = result.stdout.replace('\n', '')
         url = 'http://{0}:8089'.format(loadgen_ip)

--- a/tests/provisioning/loadgen_test.py
+++ b/tests/provisioning/loadgen_test.py
@@ -56,7 +56,7 @@ class TestLoadGenerator(unittest.TestCase):
 
     def testReachOfLoadgen(self):
         """Test if querying load generator returns 200"""
-        command = (f"kubectl get service locust-main --context=%s -o jsonpath='\{.status.loadBalancer.ingress[0].ip\}'" % TestLoadGenerator.context)
+        command = ("kubectl get service locust-main --context=%s -o jsonpath='\{.status.loadBalancer.ingress[0].ip\}'" % TestLoadGenerator.context)
         result = subprocess.run(split(command), encoding='utf-8', capture_output=True)
         loadgen_ip = result.stdout.replace('\n', '')
         url = 'http://{0}:8089'.format(loadgen_ip)

--- a/tests/provisioning/loadgen_test.py
+++ b/tests/provisioning/loadgen_test.py
@@ -52,7 +52,7 @@ class TestLoadGenerator(unittest.TestCase):
 
     def testReachOfLoadgen(self):
         """Test if querying load generator returns 200"""
-        command = ("kubectl get service locust-main --context=loadgenerator -o jsonpath='{.status.loadBalancer.ingress[0].ip}'")
+        command = ("kubectl get service locust-main -o jsonpath='{.status.loadBalancer.ingress[0].ip}'")
         result = subprocess.run(split(command), encoding='utf-8', capture_output=True)
         loadgen_ip = result.stdout.replace('\n', '')
         url = 'http://{0}:8089'.format(loadgen_ip)

--- a/tests/provisioning/loadgen_test.py
+++ b/tests/provisioning/loadgen_test.py
@@ -56,7 +56,7 @@ class TestLoadGenerator(unittest.TestCase):
 
     def testReachOfLoadgen(self):
         """Test if querying load generator returns 200"""
-        command = ("kubectl get service locust-main --context=%s -o jsonpath='\{.status.loadBalancer.ingress[0].ip\}'" % TestLoadGenerator.context)
+        command = ("kubectl get service locust-main --context=%s -o jsonpath='{.status.loadBalancer.ingress[0].ip}'" % TestLoadGenerator.context)
         result = subprocess.run(split(command), encoding='utf-8', capture_output=True)
         loadgen_ip = result.stdout.replace('\n', '')
         url = 'http://{0}:8089'.format(loadgen_ip)

--- a/tests/provisioning/provision_test.py
+++ b/tests/provisioning/provision_test.py
@@ -61,7 +61,7 @@ class TestGKECluster(unittest.TestCase):
 
     def testReachOfHipsterShop(self):
         """ Test if querying hipster shop returns 200 """
-        command = ("kubectl -n istio-system get service istio-ingressgateway --context=cloud-ops-sandbox -o jsonpath='{.status.loadBalancer.ingress[0].ip}'")
+        command = ("kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'")
         result = subprocess.run(split(command), encoding='utf-8', capture_output=True)
         external_ip = result.stdout.replace('\n', '')
         url = 'http://{0}'.format(external_ip)

--- a/tests/provisioning/provision_test.py
+++ b/tests/provisioning/provision_test.py
@@ -36,7 +36,11 @@ class TestGKECluster(unittest.TestCase):
         # set kubectl context
         command=('gcloud container clusters get-credentials cloud-ops-sandbox --zone {0}'.format(getClusterZone()))
         subprocess.run(split(command))
-    
+        # obtain the context name
+        command=('kubectl config current-context')
+        result = subprocess.run(split(command), encoding='utf-8', capture_output=True)
+        cls.context = result.stdout
+
     def testNodeMachineType(self):
         """ Test if the machine type for the nodes is as specified """
         client = cluster_manager.ClusterManagerClient()
@@ -50,10 +54,10 @@ class TestGKECluster(unittest.TestCase):
         cluster_info = client.get_cluster(name=TestGKECluster.name)
         node_count = cluster_info.current_node_count
         self.assertTrue(node_count == 4)
-    
+
     def testStatusOfServices(self):
         """ Test if all the service deployments are ready """
-        command = ("kubectl get deployment --all-namespaces -o json")
+        command = ("kubectl get deployment --context=%s --all-namespaces -o json" % TestGKECluster.context)
         result = subprocess.run(split(command), encoding='utf-8', capture_output=True)
         services = json.loads(result.stdout)
         for service in services['items']:
@@ -61,7 +65,7 @@ class TestGKECluster(unittest.TestCase):
 
     def testReachOfHipsterShop(self):
         """ Test if querying hipster shop returns 200 """
-        command = ("kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'")
+        command = ("kubectl -n istio-system get service istio-ingressgateway --context=%s -o jsonpath='{.status.loadBalancer.ingress[0].ip}'" % TestGKECluster.context)
         result = subprocess.run(split(command), encoding='utf-8', capture_output=True)
         external_ip = result.stdout.replace('\n', '')
         url = 'http://{0}'.format(external_ip)
@@ -78,7 +82,7 @@ class TestProjectResources(unittest.TestCase):
         api_enabled = result.stdout.strip().split('\n')
         for api in api_requested:
             self.assertTrue(api in api_enabled)
-    
+
     def testErrorReporting(self):
         """ Test if we can report error using Error Reporting API """
         client = error_reporting.Client(project=getProjectId())

--- a/tests/provisioning/test_runner.py
+++ b/tests/provisioning/test_runner.py
@@ -16,4 +16,8 @@
 import unittest
 
 test_suite = unittest.TestLoader().discover(pattern='*_test.py', start_dir='.')
-unittest.TextTestRunner(verbosity=2, failfast=True).run(test_suite)
+result = unittest.TextTestRunner(verbosity=2, failfast=True).run(test_suite)
+if result.wasSuccessful():
+    exit(0)
+else:
+    exit(1)


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/452
- fixed test-runner.py to exit 0 when tests fail
- fixed provisioning tests to pass (use implicit context instead of named one)
- moved "Test Using Existing Project" to bottom of the end-to-end release test, so it doesn't fail due to https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/453