### PR TITLE
Add Sandboxctl to path

### DIFF
--- a/cloud-shell/Dockerfile
+++ b/cloud-shell/Dockerfile
@@ -28,8 +28,5 @@ RUN python3 -m pip install google-cloud-monitoring
 # set env var
 RUN echo "VERSION=v0.3.0" >> /etc/environment
 
-# add sre-recipe CLI to PATH
-ENV PATH="/cloud-ops-sandbox/sre-recipes/sandboxctl:${PATH}"
-
 # Change "Open in Cloudshell" script to run ./install.sh using local file and changing it
 COPY cloudshell_open_cp.sh /google/devshell/bashrc.google.d/cloudshell_open.sh

--- a/cloud-shell/cloudshell_open_cp.sh
+++ b/cloud-shell/cloudshell_open_cp.sh
@@ -84,6 +84,8 @@ function cloudshell_open {
     done <<< "$output"
   fi
   # add sandboxctl to path
+  # the repo was previouly called stackdriver-sandbox. Now it's cloud-ops-sandbox
+  # we will add both directories to the path to support forks with either name
   export PATH="~/cloudshell_open/cloud-ops-sandbox/sre-recipes:$PATH"
   export PATH="~/cloudshell_open/stackdriver-sandbox/sre-recipes:$PATH"
   # add terraform directory to path

--- a/cloud-shell/cloudshell_open_cp.sh
+++ b/cloud-shell/cloudshell_open_cp.sh
@@ -83,5 +83,11 @@ function cloudshell_open {
       try_envset "$line"
     done <<< "$output"
   fi
+  # add sandboxctl to path
+  export PATH="~/cloudshell_open/cloud-ops-sandbox/sre-recipes:$PATH"
+  export PATH="~/cloudshell_open/stackdriver-sandbox/sre-recipes:$PATH"
+  # add terraform directory to path
+  export PATH="~/cloudshell_open/cloud-ops-sandbox/terraform:$PATH"
+  export PATH="~/cloudshell_open/stackdriver-sandbox/terraform:$PATH"
   ./install.sh # This line automatically runs the install script when cloudshell button is pressed
 }


### PR DESCRIPTION
- added sandboxctl to the path so we can now call it from anywhere in the custom cloud shell container.
- also added the terraform directory so we can call `install.sh` and `destroy.sh` from other directories (should we merge these into sandboxctl?)
- I added paths for both stackdriver-sandbox and cloud-ops-sandbox so Open in Cloud Shell buttons pointing at legacy forks still get this feature


[Open in Cloud Shell](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=master&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/sanche-testing-project/cloud-shell:test3)