### PR TITLE
Fix destroy script

### DIFF
--- a/terraform/destroy.sh
+++ b/terraform/destroy.sh
@@ -65,7 +65,7 @@ if [[ -z "${owned_projects}" ]]; then
     exit 1
 else
     log "which Cloud Operations Sandbox project do you want to delete?:"
-    select opt in $owned_projects "cancel"; do
+    select opt in ${owned_projects[@]} "cancel"; do
         if [[ "${opt}" == "cancel" ]]; then
             exit 0
         elif [[ -z "${opt}" ]]; then


### PR DESCRIPTION
- Fixed issue where destroy.sh script would only show you one option

[Open in Cloud Shell](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/Daniel-Sanche/stackdriver-sandbox.git&cloudshell_git_branch=fix-destroy-script&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.3.0)