### PR TITLE
Patch #448: Better solves MDS/GoogleAuth/Istio race condition

### DIFF
--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/cloud-ops-sandbox-3908905088/emailimage:latest
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/emailservice:latest
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -26,14 +26,9 @@ spec:
         app: emailservice
     spec:
       terminationGracePeriodSeconds: 5
-      # Verify GKE-MDS DNS as it takes time to start up. Prevents auth race condition in Python container.
-      initContainers:
-      - name: wait-for-gke-metadata-server
-        image: busybox:1.32
-        command: ['sh', '-c', 'for i in {1..10}; do sleep 1; if nslookup metadata.google.internal; then exit 0; fi; done; exit 0']
       containers:
       - name: server
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/emailservice:latest
+        image: gcr.io/cloud-ops-sandbox-3908905088/emailimage:latest
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/cloud-ops-sandbox-3908905088/recimage:latest
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/recommendationservice:latest
         ports:
         - containerPort: 8080
         env:

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -26,14 +26,9 @@ spec:
         app: recommendationservice
     spec:
       terminationGracePeriodSeconds: 5
-      # Verify GKE-MDS DNS as it takes time to start up. Prevents auth race condition in Python container.
-      initContainers:
-      - name: wait-for-gke-metadata-server
-        image: busybox:1.32
-        command: ['sh', '-c', 'for i in {1..10}; do sleep 1; if nslookup metadata.google.internal; then exit 0; fi; done; exit 0']
       containers:
       - name: server
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/recommendationservice:latest
+        image: gcr.io/cloud-ops-sandbox-3908905088/recimage:latest
         ports:
         - containerPort: 8080
         env:

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -42,6 +42,7 @@ resource "random_shuffle" "zone" {
 resource "google_container_cluster" "gke" {
   provider = google-beta
   project = data.google_project.project.project_id
+  min_master_version = "1.16.13-gke.1"
 
   # Here's how you specify the name
   name = "cloud-ops-sandbox"

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -42,7 +42,7 @@ resource "random_shuffle" "zone" {
 resource "google_container_cluster" "gke" {
   provider = google-beta
   project = data.google_project.project.project_id
-  min_master_version = "1.16.13-gke.1"
+  min_master_version = "1.17.9-gke.1504"
 
   # Here's how you specify the name
   name = "cloud-ops-sandbox"
@@ -122,7 +122,7 @@ resource "google_container_cluster" "gke" {
 }
 
 
-# Set current project 
+# Set current project
 resource "null_resource" "current_project" {
   provisioner "local-exec" {
     command = "gcloud config set project ${data.google_project.project.project_id}"
@@ -187,7 +187,7 @@ resource "null_resource" "install_istio" {
   depends_on = [null_resource.set_editor]
 }
 
-# Deploy microservices into GKE cluster 
+# Deploy microservices into GKE cluster
 resource "null_resource" "deploy_services" {
   provisioner "local-exec" {
     command = "kubectl apply -f ../kubernetes-manifests"

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -42,7 +42,7 @@ resource "random_shuffle" "zone" {
 resource "google_container_cluster" "gke" {
   provider = google-beta
   project = data.google_project.project.project_id
-  min_master_version = "1.17.9-gke.1504"
+  min_master_version = "1.16.13-gke.401"
 
   # Here's how you specify the name
   name = "cloud-ops-sandbox"

--- a/terraform/istio/install_istio.sh
+++ b/terraform/istio/install_istio.sh
@@ -55,7 +55,7 @@ kubectl create clusterrolebinding cluster-admin-binding \
 
 # Can also set flag here if values isn't actually being read...https://istio.io/v1.4/docs/setup/install/istioctl/
 # install using operator config - https://istio.io/docs/setup/install/istioctl/#customizing-the-configuration
-${WORK_DIR}/istioctl manifest install --set values.global.proxy.holdApplicationUntilProxyStarts=true ${WORK_DIR}/istio_operator.yaml
+${WORK_DIR}/istioctl manifest install -f ${WORK_DIR}/istio_operator.yaml
 
 # apply manifests
 kubectl apply -f ${WORK_DIR}/../../istio-manifests

--- a/terraform/istio/install_istio.sh
+++ b/terraform/istio/install_istio.sh
@@ -22,7 +22,7 @@ echo "### Begin install istio control plane"
 echo "### "
 
 # Set vars for DIRs
-ISTIO_VERSION="${ISTIO_VERSION:-1.6.2}"
+ISTIO_VERSION="${ISTIO_VERSION:-1.7.1}"
 
 # Set the working directory to our current directory (/sandbox/terraform/istio)
 export SCRIPTPATH=$(dirname $(realpath $0))

--- a/terraform/istio/install_istio.sh
+++ b/terraform/istio/install_istio.sh
@@ -53,8 +53,9 @@ kubectl create clusterrolebinding cluster-admin-binding \
     --clusterrole=cluster-admin \
     --user=$(gcloud config get-value core/account)
 
+# Can also set flag here if values isn't actually being read...https://istio.io/v1.4/docs/setup/install/istioctl/
 # install using operator config - https://istio.io/docs/setup/install/istioctl/#customizing-the-configuration
-${WORK_DIR}/istioctl manifest apply -f ${WORK_DIR}/istio_operator.yaml
+${WORK_DIR}/istioctl manifest install --set values.global.proxy.holdApplicationUntilProxyStarts=true ${WORK_DIR}/istio_operator.yaml
 
 # apply manifests
 kubectl apply -f ${WORK_DIR}/../../istio-manifests

--- a/terraform/istio/istio_operator.yaml
+++ b/terraform/istio/istio_operator.yaml
@@ -110,15 +110,6 @@ spec:
             maxSurge: "100%"
             maxUnavailable: "25%"
 
-    # Security feature
-    citadel:
-      enabled: false
-      k8s:
-        strategy:
-          rollingUpdate:
-            maxSurge: "100%"
-            maxUnavailable: "25%"
-
     # Istio Gateway feature
     ingressGateways:
     - name: istio-ingressgateway

--- a/terraform/istio/istio_operator.yaml
+++ b/terraform/istio/istio_operator.yaml
@@ -212,6 +212,8 @@ spec:
           host: # example: statsd-svc.istio-system
           port: # example: 9125
         tracer: "zipkin"
+        # Controls if sidecar is injected at the front of the container list and blocks the start of the other containers until the proxy is ready
+        holdApplicationUntilProxyStarts: false
       proxy_init:
         image: proxyv2
         resources:

--- a/terraform/istio/istio_operator.yaml
+++ b/terraform/istio/istio_operator.yaml
@@ -213,7 +213,7 @@ spec:
           port: # example: 9125
         tracer: "zipkin"
         # Controls if sidecar is injected at the front of the container list and blocks the start of the other containers until the proxy is ready
-        holdApplicationUntilProxyStarts: false
+        holdApplicationUntilProxyStarts: true
       proxy_init:
         image: proxyv2
         resources:

--- a/terraform/istio/istio_operator.yaml
+++ b/terraform/istio/istio_operator.yaml
@@ -168,7 +168,6 @@ spec:
     global:
       istioNamespace: istio-system
       istiod:
-        enabled: true
         enableAnalysis: false
       logging:
         level: "default:info"
@@ -242,7 +241,6 @@ spec:
       multiCluster:
         enabled: false
         clusterName: ""
-      canaryvalue: true
       omitSidecarInjectorConfigMap: false
       network: ""
       defaultResources:

--- a/terraform/istio/istio_operator.yaml
+++ b/terraform/istio/istio_operator.yaml
@@ -212,8 +212,6 @@ spec:
           host: # example: statsd-svc.istio-system
           port: # example: 9125
         tracer: "zipkin"
-        # Controls if sidecar is injected at the front of the container list and blocks the start of the other containers until the proxy is ready
-        holdApplicationUntilProxyStarts: false
       proxy_init:
         image: proxyv2
         resources:

--- a/terraform/istio/istio_operator.yaml
+++ b/terraform/istio/istio_operator.yaml
@@ -198,10 +198,6 @@ spec:
         excludeOutboundPorts: ""
         excludeInboundPorts: ""
         autoInject: enabled
-        envoyStatsd:
-          enabled: false
-          host: # example: statsd-svc.istio-system
-          port: # example: 9125
         tracer: "zipkin"
         # Controls if sidecar is injected at the front of the container list and blocks the start of the other containers until the proxy is ready
         holdApplicationUntilProxyStarts: true

--- a/terraform/istio/istio_operator.yaml
+++ b/terraform/istio/istio_operator.yaml
@@ -242,6 +242,7 @@ spec:
       multiCluster:
         enabled: false
         clusterName: ""
+      canaryvalue: true
       omitSidecarInjectorConfigMap: false
       network: ""
       defaultResources:


### PR DESCRIPTION
This PR patches #448 , and fully closes #371 and #372 . Also:
- Upgrades GKE to v1.15 -> v1.16 
- Upgrades Istio 1.5-1.7, which contained the `holdApplicationUntilProxyStarts: true` flag that fixes race condition

**Details**
The previous PR didn't handle Istio's role in the race condition, esp since InitContainer runs before Istio injection. So we occasionally still got DefaultCredentialsError. This PR fixes the race conditions in a less latent/hacky way.

The Full Race Condition:
1. `Initcontainer` within `AppContainer` starts and finishes
2. `Istio` starts.
3. [In parallel as 2] AppContainer starts. _AppContainer errors and crashes bc of missing certs. This is because Istio's envoy proxy isn't always ready yet._
4. Envoy finally gets cert configs & proxy is ready. _This delay is in part due to slow GKE-MDS startup_
5. AppContainer restarts after crashing in step 3
6. AppContainer succeeds auth this time, as proxy certs are available

Steps 2-4 take 10-30 seconds. Hence this issue was difficult to consistently reproduce. 

**More info on the Istio fix** 
https://banzaicloud.com/blog/k8s-sidecars/ 
https://github.com/kubernetes/kubernetes/issues/65502 
Fix: https://github.com/istio/istio/pull/26149

**Before:**  
Initializing RecommendationService during Istio configs
<img width="1533" alt="Run before configuring istio" src="https://user-images.githubusercontent.com/69952136/93040049-f0944000-f5fd-11ea-93f3-1d95d62915e2.png">

**After:** 
Initializing RecommendationService after Istio
![Run after configuring istio](https://user-images.githubusercontent.com/69952136/93040052-f25e0380-f5fd-11ea-8723-2ebb2a52f4d0.png)
