### PR TITLE
CLI refactor and hint method for sre recipes

### DIFF
--- a/sre-recipes/README.md
+++ b/sre-recipes/README.md
@@ -21,7 +21,10 @@ To verify the root cause of the breakage in specific recipe, run:
 ```
 $ ./sandboxctl verify <recipe_name>
 ```
-
+To receive a hint about the root cause of the breakage, run:
+```
+$ ./sandboxctl hint <recipe_name>
+```
 ## Contributing
 
 To contribute a new recipe, create a new folder in the [recipes directory](./recipes). The directory must include a class that extends the abstract base class found in [recipe.py](recipe.py).

--- a/sre-recipes/recipe.py
+++ b/sre-recipes/recipe.py
@@ -63,7 +63,7 @@ class Recipe(abc.ABC):
         get_project_command = 'gcloud config list --format value(core.project)'
         project_id, error = Recipe._run_command(get_project_command)
         project_id = project_id.decode("utf-8").replace('"', '')
-        if project_id == '':
+        if not project_id:
             print('No project found.')
             logging.error('Could not authenticate cluster. No project ID found.')
             exit(1)
@@ -73,7 +73,7 @@ class Recipe(abc.ABC):
         zone_command = 'gcloud container clusters list --filter name:{} --project {} --format value(zone)'.format(name, project_id)
         zone, error = Recipe._run_command(zone_command)
         zone = zone.decode("utf-8").replace('"', '')
-        if zone == '':
+        if not zone:
             print('Failed to set up recipe. No cluster for {} was found.'.format(name))
             logging.error('Could not authenticate cluster. No cluster found for {} found.'.format(name))
             exit(1)

--- a/sre-recipes/recipe.py
+++ b/sre-recipes/recipe.py
@@ -85,21 +85,18 @@ class Recipe(abc.ABC):
             No output
         """
         # Verify the correct exists as a choice
-        found_ans = False
-        for choice in choices:
-            if correct_answer == choice:
-                found_ans = True
-
-        if not found_ans:
-            logging.info('Correct answer not found in available choices for prompt: {}'.format(prompt))
+        if not correct_answer in choices:
+            logging.error('Correct answer not found in available choices for prompt: {}'.format(prompt))
             return
 
+        # Show the multiple choice
         print(prompt)
-        for index in range(1, len(choices)+1):
-            print("\t {}) {}".format(index, choices[index-1]))
+        for index in range(0, len(choices)):
+            print("\t {}) {}".format(index + 1, choices[index]))
 
         answer = input('Enter the number of your answer: ')
 
+        # Verify the answer
         while True:
             try:
                 answer = int(answer)

--- a/sre-recipes/recipe.py
+++ b/sre-recipes/recipe.py
@@ -57,15 +57,19 @@ class Recipe(abc.ABC):
         return output, error
 
     @staticmethod
-    def _auth_cluster():
+    def _auth_cluster(cluster="APP"):
         """ Authenticates for kubectl commands. """
         logging.info('Authenticating cluster')
         get_project_command = "gcloud config list --format value(core.project)"
         project_id, error = Recipe._run_command(get_project_command)
         project_id = project_id.decode("utf-8").replace('"', '')
-        zone_command = "gcloud container clusters list --filter name:cloud-ops-sandbox --project {} --format value(zone)".format(project_id)
+        name = "cloud-ops-sandbox"
+        if cluster == "LOADGEN":
+            name = "loadgenerator"
+        zone_command = "gcloud container clusters list --filter name:{} --project {} --format value(zone)".format(name, project_id)
         zone, error = Recipe._run_command(zone_command)
         zone = zone.decode("utf-8").replace('"', '')
-        auth_command = "gcloud container clusters get-credentials cloud-ops-sandbox --project {} --zone {}".format(project_id, zone)
+        print(zone)
+        auth_command = "gcloud container clusters get-credentials {} --project {} --zone {}".format(name, project_id, zone)
         Recipe._run_command(auth_command)
         logging.info('Cluster has been authenticated')

--- a/sre-recipes/recipe.py
+++ b/sre-recipes/recipe.py
@@ -73,3 +73,44 @@ class Recipe(abc.ABC):
         auth_command = "gcloud container clusters get-credentials {} --project {} --zone {}".format(name, project_id, zone)
         Recipe._run_command(auth_command)
         logging.info('Cluster has been authenticated')
+
+    @staticmethod
+    def _generate_multiple_choice(prompt, choices, correct_answer):
+        """ Creates a multiple choice quiz using numeric answers and prints to terminal. Automatically polls for user response.
+        Input:
+            prompt - (string) the question asked to the user
+            choice - (list of strings) a list of responses. They will automatically be ennumerated 
+            correct_answer - (string) the correct answer - must string match with one of the entries in the choice array
+        Output:
+            No output
+        """
+        # Verify the correct exists as a choice
+        found_ans = False
+        for choice in choices:
+            if correct_answer == choice:
+                found_ans = True
+
+        if not found_ans:
+            logging.info('Correct answer not found in available choices for prompt: {}'.format(prompt))
+            return
+
+        print(prompt)
+        for index in range(1, len(choices)+1):
+            print("\t {}) {}".format(index, choices[index-1]))
+
+        answer = input('Enter the number of your answer: ')
+
+        while True:
+            try:
+                answer = int(answer)
+                if answer < 1 or answer > len(choices):
+                    print('Not a valid choice.')
+                elif choices[answer-1] == correct_answer:
+                    print('Correct!')
+                    return
+                else:
+                    print('Incorrect. Try again.')
+            except ValueError:
+                print('Please enter the number of your answer.')
+
+            answer = input('Enter the number of your answer: ')

--- a/sre-recipes/recipe.py
+++ b/sre-recipes/recipe.py
@@ -69,5 +69,3 @@ class Recipe(abc.ABC):
         auth_command = "gcloud container clusters get-credentials cloud-ops-sandbox --project {} --zone {}".format(project_id, zone)
         Recipe._run_command(auth_command)
         logging.info('Cluster has been authenticated')
-
-

--- a/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
+++ b/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
@@ -84,54 +84,25 @@ class CurrenciesRecipe(Recipe):
         project_id = project_id.decode("utf-8").replace('"', '')
         print('Use Monitoring Dashboards to see metrics associated with each service: https://console.cloud.google.com/monitoring/dashboards?project={}'.format(project_id))
 
-    def service_multiple_choice(self):
+    def verify_broken_service(self):
         """
         Displays a multiple choice quiz to the user about which service
         broke and prompts the user for an answer
         """
-        print("Which service broke?\n"
-                "\t[a] ad service \n"
-                "\t[b] cart service \n"
-                "\t[c] checkout service \n"
-                "\t[d] currency service \n"
-                "\t[e] email service \n"
-                "\t[f] frontend service \n"
-                "\t[g] payment service \n"
-                "\t[h] product catalog service \n"
-                "\t[i] recommendation service \n"
-                "\t[j] redis \n"
-                "\t[k] shipping service")
-        answer = input('Your answer: ')
-        return answer
+        prompt = 'Which service has a breakage?'
+        choices = ['email service', 'frontend service', 'ad service', 'recommendation service', 'currency service']
+        answer = 'frontend service'
+        Recipe._generate_multiple_choice(prompt, choices, answer)
 
-    def cause_multiple_choice(self):
+    def verify_broken_cause(self):
         """
         Displays a multiple choice quiz to the user about the cause of
         the breakage and prompts the user for an answer
         """
-        print('What caused the breakage?')
-        print('\t[a] failed connections to other services')
-        print('\t[b] high memory usage')
-        print('\t[c] high latency')
-        print('\t[d] dropped requests')
-        answer = input('Your answer: ')
-        return answer
-
-    def verify_broken_service(self):
-        """Verifies the user found which service broke"""
-        answer = self.service_multiple_choice()
-        while answer.lower() != 'f':
-            print('Incorrect. Please try again.')
-            answer = input('Your answer: ')
-        print('Correct! The frontend service is broken.')
-
-    def verify_broken_cause(self):
-        """Verifies the user found the root cause of the breakage"""
-        answer = self.cause_multiple_choice()
-        while answer.lower() != 'c':
-            print('Incorrect. Please try again.')
-            answer = input('Your answer: ')
-        print('Correct! High latency caused the breakage.')
+        prompt = 'What caused the breakage?'
+        choices = ['failed connections to other services', 'high memory usage', 'high latency', 'dropped requests']
+        answer = 'high latency'
+        Recipe._generate_multiple_choice(prompt, choices, answer)
 
     def verify(self):
         """Verifies the user found the root cause of the broken service"""

--- a/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
+++ b/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
@@ -14,7 +14,7 @@
 
 # -*- coding: utf-8 -*-
 """
-This module contains the implementation of recipe 1
+This module contains the implementation of recipe 0
 """
 
 import logging
@@ -24,16 +24,9 @@ from recipe import Recipe
 
 class CurrenciesRecipe(Recipe):
     """
-    This class implements recipe 1, which purposefully
+    This class implements recipe 0, which purposefully
     introduces latency into the frontend service.
     """
-
-    @staticmethod
-    def _run_command(command):
-        """Runs the given command and returns any output and error"""
-        process = subprocess.Popen(command.split(), stdout=subprocess.PIPE)
-        output, error = process.communicate()
-        return output, error
 
     @staticmethod
     def _deploy_state(state):
@@ -48,36 +41,22 @@ class CurrenciesRecipe(Recipe):
         logging.info('Setting env variable: %s', set_env_command)
         logging.info('Getting pod: %s', get_pod_command)
 
-        CurrenciesRecipe._run_command(set_env_command)
-        service, error = CurrenciesRecipe._run_command(get_pod_command)
+        Recipe._run_command(set_env_command)
+        service, error = Recipe._run_command(get_pod_command)
         service = service.decode("utf-8").replace('"', '')
         delete_pod_command = f"kubectl delete pod {service}"
         logging.info('Deleting pod: %s', delete_pod_command)
-        CurrenciesRecipe._run_command(delete_pod_command)
-
-    @staticmethod
-    def _auth_cluster():
-        """ Authenticates for kubectl commands. """
-        logging.info('Authenticating cluster')
-        get_project_command = "gcloud config list --format value(core.project)"
-        project_id, error = CurrenciesRecipe._run_command(get_project_command)
-        project_id = project_id.decode("utf-8").replace('"', '')
-        zone_command = "gcloud container clusters list --filter name:cloud-ops-sandbox --project {} --format value(zone)".format(project_id)
-        zone, error = CurrenciesRecipe._run_command(zone_command)
-        zone = zone.decode("utf-8").replace('"', '')
-        auth_command = "gcloud container clusters get-credentials cloud-ops-sandbox --project {} --zone {}".format(project_id, zone)
-        CurrenciesRecipe._run_command(auth_command)
-        logging.info('Cluster has been authenticated')
+        Recipe._run_command(delete_pod_command)
 
     def break_service(self):
         """
         Rolls back the working version of the given service and deploys the
         broken version of the given service
         """
-        print("Deploying broken service...")
-        self._auth_cluster()
+        print('Deploying broken service...')
+        Recipe._auth_cluster()
         self._deploy_state(True)
-        print("Done")
+        print('Done')
         logging.info('Deployed broken service')
 
     def restore_service(self):
@@ -85,13 +64,27 @@ class CurrenciesRecipe(Recipe):
         Rolls back the broken version of the given service and deploys the
         working version of the given service
         """
-        print("Deploying working service...")
-        self._auth_cluster()
+        print('Deploying working service...')
+        Recipe._auth_cluster()
         self._deploy_state(False)
-        print("Done")
+        print('Done')
         logging.info('Deployed working service')
 
-    def _service_multiple_choice(self):
+    def hint(self):
+        """
+        Provides a hint about finding the root cause of this recipe
+        """
+        print('Giving hint for recipe')
+        external_ip_command = "kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'"
+        ip, error = Recipe._run_command(external_ip_command)
+        ip = ip.decode("utf-8").replace("'", '')
+        print('Visit the external IP of the demo application to see if there are any visible changes: http://{}'.format(ip))
+        get_project_command = "gcloud config list --format value(core.project)"
+        project_id, error = Recipe._run_command(get_project_command)
+        project_id = project_id.decode("utf-8").replace('"', '')
+        print('Use Monitoring Dashboards to see metrics associated with each service: https://console.cloud.google.com/monitoring/dashboards?project={}'.format(project_id))
+
+    def service_multiple_choice(self):
         """
         Displays a multiple choice quiz to the user about which service
         broke and prompts the user for an answer
@@ -111,7 +104,7 @@ class CurrenciesRecipe(Recipe):
         answer = input('Your answer: ')
         return answer
 
-    def _cause_multiple_choice(self):
+    def cause_multiple_choice(self):
         """
         Displays a multiple choice quiz to the user about the cause of
         the breakage and prompts the user for an answer
@@ -124,17 +117,17 @@ class CurrenciesRecipe(Recipe):
         answer = input('Your answer: ')
         return answer
 
-    def _verify_broken_service(self):
+    def verify_broken_service(self):
         """Verifies the user found which service broke"""
-        answer = self._service_multiple_choice()
+        answer = self.service_multiple_choice()
         while answer.lower() != 'f':
             print('Incorrect. Please try again.')
             answer = input('Your answer: ')
         print('Correct! The frontend service is broken.')
 
-    def _verify_broken_cause(self):
+    def verify_broken_cause(self):
         """Verifies the user found the root cause of the breakage"""
-        answer = self._cause_multiple_choice()
+        answer = self.cause_multiple_choice()
         while answer.lower() != 'c':
             print('Incorrect. Please try again.')
             answer = input('Your answer: ')
@@ -144,7 +137,7 @@ class CurrenciesRecipe(Recipe):
         """Verifies the user found the root cause of the broken service"""
         print("This is a multiple choice quiz to verify that you've")
         print('found the root cause of the break')
-        self._verify_broken_service()
-        self._verify_broken_cause()
+        self.verify_broken_service()
+        self.verify_broken_cause()
         print('Good job! You have correctly identified which service broke')
         print('and what caused it to break!')

--- a/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
+++ b/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
@@ -44,6 +44,9 @@ class CurrenciesRecipe(Recipe):
         Recipe._run_command(set_env_command)
         service, error = Recipe._run_command(get_pod_command)
         service = service.decode("utf-8").replace('"', '')
+        if service == '':
+            print('No service found. Could not deploy state.')
+            logging.error('No service found. Could not deploy state.')
         delete_pod_command = f"kubectl delete pod {service}"
         logging.info('Deleting pod: %s', delete_pod_command)
         Recipe._run_command(delete_pod_command)
@@ -79,10 +82,18 @@ class CurrenciesRecipe(Recipe):
         external_ip_command = "kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'"
         ip, error = Recipe._run_command(external_ip_command)
         ip = ip.decode("utf-8").replace("'", '')
+        if ip == '':
+            print('No external IP found.')
+            logging.error('No external IP found.')
+            exit(1)
         print('Visit the external IP of the demo application to see if there are any visible changes: http://{}'.format(ip))
         get_project_command = "gcloud config list --format value(core.project)"
         project_id, error = Recipe._run_command(get_project_command)
         project_id = project_id.decode("utf-8").replace('"', '')
+        if project_id == '':
+            print('No project ID found.')
+            logging.error('No project ID found.')
+            exit(1)
         print('Use Monitoring Dashboards to see metrics associated with each service: https://console.cloud.google.com/monitoring/dashboards?project={}'.format(project_id))
 
     def verify_broken_service(self):

--- a/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
+++ b/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
@@ -107,7 +107,17 @@ class CurrenciesRecipe(Recipe):
 
     def verify(self):
         """Verifies the user found the root cause of the broken service"""
-        print('This is a multiple choice quiz to verify that you have \nfound the root cause of the breakage.')
+        print(
+        '''
+        This is a multiple choice quiz to verify that 
+        you have found the root cause of the breakage.
+        '''
+            )
         self.verify_broken_service()
         self.verify_broken_cause()
-        print('Good job! You have correctly identified which service broke \nand what caused it to break.')
+        print(
+        '''
+        Good job! You have correctly identified which 
+        service broke and what caused it to break.
+        '''
+            )

--- a/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
+++ b/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
@@ -44,7 +44,7 @@ class CurrenciesRecipe(Recipe):
         Recipe._run_command(set_env_command)
         service, error = Recipe._run_command(get_pod_command)
         service = service.decode("utf-8").replace('"', '')
-        if service == '':
+        if not service:
             print('No service found. Could not deploy state.')
             logging.error('No service found. Could not deploy state.')
         delete_pod_command = f"kubectl delete pod {service}"
@@ -82,7 +82,7 @@ class CurrenciesRecipe(Recipe):
         external_ip_command = "kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'"
         ip, error = Recipe._run_command(external_ip_command)
         ip = ip.decode("utf-8").replace("'", '')
-        if ip == '':
+        if not ip:
             print('No external IP found.')
             logging.error('No external IP found.')
             exit(1)
@@ -90,7 +90,7 @@ class CurrenciesRecipe(Recipe):
         get_project_command = "gcloud config list --format value(core.project)"
         project_id, error = Recipe._run_command(get_project_command)
         project_id = project_id.decode("utf-8").replace('"', '')
-        if project_id == '':
+        if not project_id:
             print('No project ID found.')
             logging.error('No project ID found.')
             exit(1)

--- a/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
+++ b/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
@@ -75,6 +75,7 @@ class CurrenciesRecipe(Recipe):
         Provides a hint about finding the root cause of this recipe
         """
         print('Giving hint for recipe')
+        Recipe._auth_cluster()
         external_ip_command = "kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'"
         ip, error = Recipe._run_command(external_ip_command)
         ip = ip.decode("utf-8").replace("'", '')
@@ -106,9 +107,7 @@ class CurrenciesRecipe(Recipe):
 
     def verify(self):
         """Verifies the user found the root cause of the broken service"""
-        print("This is a multiple choice quiz to verify that you've")
-        print('found the root cause of the break')
+        print('This is a multiple choice quiz to verify that you have \nfound the root cause of the breakage.')
         self.verify_broken_service()
         self.verify_broken_cause()
-        print('Good job! You have correctly identified which service broke')
-        print('and what caused it to break!')
+        print('Good job! You have correctly identified which service broke \nand what caused it to break.')

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -76,7 +76,7 @@ def get_recipes():
 
 RECIPES = get_recipes()
 @click.command()
-@click.argument('action', type=click.Choice(['break', 'restore', 'verify']))
+@click.argument('action', type=click.Choice(['break', 'restore', 'verify', 'hint']))
 @click.argument('recipe_name', type=click.Choice(RECIPES.keys()))
 def main(action, recipe_name):
     """Performs an action on a recipe."""
@@ -92,6 +92,9 @@ def main(action, recipe_name):
     elif action == 'verify':
         logging.info('Verifying %s', recipe_name)
         recipe.verify()
+    elif action == 'hint':
+        logging.info('Giving hint for %s', recipe_name)
+        recipe.hint()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#WHAT: Refactors the sandboxctl CLI - moves the authentication and command running into the base class so it's usable by other recipes (since this will most likely be the case) and also uniforms naming across static and class methods. Also fixes some naming.

#WHY: Makes the CLI more portable for additional recipes