### PR TITLE
SRE Recipe introducing errors into the email service

### DIFF
--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 import grpc
+import base64
 from jinja2 import Environment, FileSystemLoader, select_autoescape, TemplateError
 from google.api_core.exceptions import GoogleAPICallError
 from google.auth.exceptions import DefaultCredentialsError
@@ -120,7 +121,26 @@ class EmailService(BaseEmailService):
 class DummyEmailService(BaseEmailService):
   def SendOrderConfirmation(self, request, context):
     logger.info('A request to send order confirmation email to {} has been received.'.format(request.email))
+    if self.EncodeEmail(request.email):
+      logger.error('Err: Could not encode email')
+      context.set_code(grpc.StatusCode.INTERNAL)
     return demo_pb2.Empty()
+
+  def EncodeEmail(self, email):
+    """ 
+    Encodes the email address to base64 encoding
+    Input: 
+      email - (string) the email address
+    Output:
+      boolean - whether the encoding was successful or not
+    """
+    if os.getenv('ENCODE_EMAIL').lower() == "true":
+      byte_rep = email.encode('ascii')
+      b64_bytes = base64.b64encode(byte_rep)
+      encoded = b64_bytes.decode('ascii')
+      return True
+    else:
+      return False
 
 class HealthCheck():
   def Check(self, request, context):

--- a/sre-recipes/recipe.py
+++ b/sre-recipes/recipe.py
@@ -29,6 +29,10 @@ class Recipe(abc.ABC):
     """
 
     @abc.abstractmethod
+    def get_name(self):
+        """ Returns the name of the recipe"""
+
+    @abc.abstractmethod
     def break_service(self):
         """Deploys the broken service"""
 

--- a/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
+++ b/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
@@ -27,6 +27,10 @@ class CurrenciesRecipe(Recipe):
     This class implements recipe 0, which purposefully
     introduces latency into the frontend service.
     """
+    name = "currency_recipe"
+    
+    def get_name(self):
+        return self.name
 
     @staticmethod
     def _deploy_state(state):

--- a/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
+++ b/sre-recipes/recipes/currencies_recipe/currencies_recipe.py
@@ -27,8 +27,8 @@ class CurrenciesRecipe(Recipe):
     This class implements recipe 0, which purposefully
     introduces latency into the frontend service.
     """
-    name = "currency_recipe"
-    
+    name = "recipe0"
+
     def get_name(self):
         return self.name
 
@@ -54,6 +54,8 @@ class CurrenciesRecipe(Recipe):
         delete_pod_command = f"kubectl delete pod {service}"
         logging.info('Deleting pod: %s', delete_pod_command)
         Recipe._run_command(delete_pod_command)
+        availability_command = "kubectl wait --for=condition=available --timeout=600s deployment/frontend"
+        Recipe._run_command(availability_command)
 
     def break_service(self):
         """

--- a/sre-recipes/recipes/encoding_recipe/__init__.py
+++ b/sre-recipes/recipes/encoding_recipe/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -43,7 +43,7 @@ class EncodingRecipe(Recipe):
         Recipe._run_command(set_env_command)
         service, error = Recipe._run_command(get_pod_command)
         service = service.decode("utf-8").replace('"', '')
-        if service == '':
+        if not service:
             print('No service found. Could not deploy state.')
             logging.error('No service found. Could not deploy state.')
             exit(1)
@@ -80,7 +80,7 @@ class EncodingRecipe(Recipe):
         get_project_command = "gcloud config list --format value(core.project)"
         project_id, error = Recipe._run_command(get_project_command)
         project_id = project_id.decode("utf-8").replace('"', '')
-        if project_id == '':
+        if not project_id:
             print('No project ID found.')
             logging.error('No project ID found.')
             exit(1)

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -28,7 +28,7 @@ class EncodingRecipe(Recipe):
     spits errors from the Email Service.
     """
 
-    def deploy_state(state):
+    def deploy_state(self, state):
         """
         Sets an environment variable ENCODE_EMAIL to given state
         and updates the state accordingly

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -27,7 +27,11 @@ class EncodingRecipe(Recipe):
     This class implements recipe 1, which purposefully
     spits errors from the Email Service.
     """
+    name = "encoding_recipe"
 
+    def get_name(self):
+        return self.name
+        
     def deploy_state(self, state):
         """
         Sets an environment variable ENCODE_EMAIL to given state

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -43,6 +43,10 @@ class EncodingRecipe(Recipe):
         Recipe._run_command(set_env_command)
         service, error = Recipe._run_command(get_pod_command)
         service = service.decode("utf-8").replace('"', '')
+        if service == '':
+            print('Could not deploy state. No service found.')
+            logging.error('Error: No services found while trying to deploy state')
+            exit(1)
         delete_pod_command = f"kubectl delete pod {service}"
         logging.info('Deleting pod: %s', delete_pod_command)
         Recipe._run_command(delete_pod_command)
@@ -76,6 +80,10 @@ class EncodingRecipe(Recipe):
         get_project_command = "gcloud config list --format value(core.project)"
         project_id, error = Recipe._run_command(get_project_command)
         project_id = project_id.decode("utf-8").replace('"', '')
+        if project_id == '':
+            print('No project ID found.')
+            logging.error('No project ID found.')
+            exit(1)
         print('Use Cloud Logging to view logs exported by each service: https://console.cloud.google.com/logs?project={}'.format(project_id))
 
     def verify_broken_service(self):

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -44,8 +44,8 @@ class EncodingRecipe(Recipe):
         service, error = Recipe._run_command(get_pod_command)
         service = service.decode("utf-8").replace('"', '')
         if service == '':
-            print('Could not deploy state. No service found.')
-            logging.error('Error: No services found while trying to deploy state')
+            print('No service found. Could not deploy state.')
+            logging.error('No service found. Could not deploy state.')
             exit(1)
         delete_pod_command = f"kubectl delete pod {service}"
         logging.info('Deleting pod: %s', delete_pod_command)

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -27,11 +27,11 @@ class EncodingRecipe(Recipe):
     This class implements recipe 1, which purposefully
     spits errors from the Email Service.
     """
-    name = "encoding_recipe"
+    name = "recipe1"
 
     def get_name(self):
         return self.name
-        
+
     def deploy_state(self, state):
         """
         Sets an environment variable ENCODE_EMAIL to given state
@@ -54,6 +54,8 @@ class EncodingRecipe(Recipe):
         delete_pod_command = f"kubectl delete pod {service}"
         logging.info('Deleting pod: %s', delete_pod_command)
         Recipe._run_command(delete_pod_command)
+        availability_command = "kubectl wait --for=condition=available --timeout=600s deployment/emailservice"
+        Recipe._run_command(availability_command)
 
     def break_service(self):
         """

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -100,13 +100,17 @@ class EncodingRecipe(Recipe):
 
     def verify(self):
         """Verifies the user found the root cause of the broken service"""
-        print('''
-            This is a multiple choice quiz to verify that 
-            you have found the root cause of the break.
-            ''')
+        print(
+        '''
+        This is a multiple choice quiz to verify that 
+        you have found the root cause of the break.
+        '''
+            )
         self.verify_broken_service()
         self.verify_broken_cause()
-        print('''
-            Good job! You have correctly identified which 
-            service broke and what caused it to break!
-            ''')
+        print(
+        '''
+        Good job! You have correctly identified which 
+        service broke and what caused it to break!
+        '''
+            )

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -100,7 +100,13 @@ class EncodingRecipe(Recipe):
 
     def verify(self):
         """Verifies the user found the root cause of the broken service"""
-        print('This is a multiple choice quiz to verify that you have \nfound the root cause of the break.')
+        print('''
+            This is a multiple choice quiz to verify that 
+            you have found the root cause of the break.
+            ''')
         self.verify_broken_service()
         self.verify_broken_cause()
-        print('Good job! You have correctly identified which service broke \nand what caused it to break!')
+        print('''
+            Good job! You have correctly identified which 
+            service broke and what caused it to break!
+            ''')

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -100,9 +100,7 @@ class EncodingRecipe(Recipe):
 
     def verify(self):
         """Verifies the user found the root cause of the broken service"""
-        print('This is a multiple choice quiz to verify that you have')
-        print('found the root cause of the break')
+        print('This is a multiple choice quiz to verify that you have \nfound the root cause of the break.')
         self.verify_broken_service()
         self.verify_broken_cause()
-        print('Good job! You have correctly identified which service broke')
-        print('and what caused it to break!')
+        print('Good job! You have correctly identified which service broke \nand what caused it to break!')

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -69,6 +69,15 @@ class EncodingRecipe(Recipe):
         print("Done")
         logging.info('Deployed working service')
 
+    def hint(self):
+        """
+        Provides a hint about the root cause of the issue
+        """
+        get_project_command = "gcloud config list --format value(core.project)"
+        project_id, error = Recipe._run_command(get_project_command)
+        project_id = project_id.decode("utf-8").replace('"', '')
+        print('Use Cloud Logging to view logs exported by each service: https://console.cloud.google.com/logs?project={}'.format(project_id))
+
     def verify_broken_service(self):
         """
         Displays a multiple choice quiz to the user about which service

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -1,0 +1,99 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- coding: utf-8 -*-
+"""
+This module contains the implementation of recipe 1
+"""
+
+import logging
+import subprocess
+from recipe import Recipe
+
+
+class EncodingRecipe(Recipe):
+    """
+    This class implements recipe 1, which purposefully
+    spits errors from the Email Service.
+    """
+
+    def deploy_state(state):
+        """
+        Sets an environment variable ENCODE_EMAIL to given state
+        and updates the state accordingly
+        """
+        state_str = str(state).lower()
+        set_env_command = f"kubectl set env deployment/emailservice ENCODE_EMAIL={state_str}"
+        get_pod_command = """kubectl get pod -l app=emailservice -o \
+            jsonpath=\"{.items[0].metadata.name}\""""
+        logging.info('Setting env variable: %s', set_env_command)
+        logging.info('Getting pod: %s', get_pod_command)
+
+        Recipe._run_command(set_env_command)
+        service, error = Recipe._run_command(get_pod_command)
+        service = service.decode("utf-8").replace('"', '')
+        delete_pod_command = f"kubectl delete pod {service}"
+        logging.info('Deleting pod: %s', delete_pod_command)
+        Recipe._run_command(delete_pod_command)
+
+    def break_service(self):
+        """
+        Rolls back the working version of the given service and deploys the
+        broken version of the given service
+        """
+        print("Deploying broken service...")
+        Recipe._auth_cluster()
+        self.deploy_state(True)
+        print("Done")
+        logging.info('Deployed broken service')
+
+    def restore_service(self):
+        """
+        Rolls back the broken version of the given service and deploys the
+        working version of the given service
+        """
+        print("Deploying working service...")
+        Recipe._auth_cluster()
+        self.deploy_state(False)
+        print("Done")
+        logging.info('Deployed working service')
+
+    def verify_broken_service(self):
+        """
+        Displays a multiple choice quiz to the user about which service
+        broke and prompts the user for an answer
+        """
+        prompt = 'Which service has a breakage?'
+        choices = ['email service', 'recommendation service', 'productcatalog service', 'cart service', 'frontend service']
+        answer = 'email service'
+        Recipe._generate_multiple_choice(prompt, choices, answer)
+
+    def verify_broken_cause(self):
+        """
+        Displays a multiple choice quiz to the user about the cause of
+        the breakage and prompts the user for an answer
+        """
+        prompt =  'What was the cause of the break?'
+        choices = ['high latency', 'internal service errors', 'failed connection to other services', 'memory quota exceeded']
+        answer = 'internal service errors'
+        Recipe._generate_multiple_choice(prompt, choices, answer)
+
+    def verify(self):
+        """Verifies the user found the root cause of the broken service"""
+        print('This is a multiple choice quiz to verify that you have')
+        print('found the root cause of the break')
+        self.verify_broken_service()
+        self.verify_broken_cause()
+        print('Good job! You have correctly identified which service broke')
+        print('and what caused it to break!')

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -26,6 +26,7 @@ For information on how to run the CLI, run the following:
 
 import logging
 import os
+import sys
 from os.path import dirname, abspath
 from pkgutil import iter_modules
 from pathlib import Path
@@ -46,7 +47,8 @@ def get_valid_recipes(attributes):
         if isclass(attribute) and attribute is not Recipe and issubclass(attribute, Recipe):
             try:
                 recipe_obj = attribute()
-                recipe_objs[f"recipe{recipe_num}"] = recipe_obj
+                name = recipe_obj.get_name()
+                recipe_objs[name] = recipe_obj
                 recipe_num += 1
             except TypeError:
                 logging.warning('%s needs to implement all abstract methods', \

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -41,11 +41,13 @@ def get_valid_recipes(attributes):
     """
 
     recipe_objs = {}
-    for recipe_num, (attribute_name, attribute) in enumerate(attributes):
+    recipe_num = 0
+    for (attribute_name, attribute) in attributes:
         if isclass(attribute) and attribute is not Recipe and issubclass(attribute, Recipe):
             try:
                 recipe_obj = attribute()
                 recipe_objs[f"recipe{recipe_num}"] = recipe_obj
+                recipe_num += 1
             except TypeError:
                 logging.warning('%s needs to implement all abstract methods', \
                     attribute_name)


### PR DESCRIPTION
#WHAT: Another SRE recipe that introduces grpc errors into the email service by attempting to encode the email when the feature flag for encoding is set to true. 

#WHY: We want another example of SRE recipes for users to play with!

#HOW: used encoding as a sample "feature" to hide what the recipe really is - which is about sending errors in both logging that should also be shown in dashboards and SLOs.