### PR TITLE
User uncertified images

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 
 Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
 
-[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.3.0)
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.3.0)
 
 __Note__: If installation stops due to billing account errors, set up the billing account, and then in the `terraform/` diretory of the project created in Cloud Shell command prompt, type: `./install.sh`.
 

--- a/cloud-shell/README.md
+++ b/cloud-shell/README.md
@@ -19,12 +19,12 @@ $ gcloud auth configure-docker
 ```
 3. Tag the image. This will enable docker to push it to the correct location (the project GCR registry), and automatically show this image as "latest" unless another tag is specified by adding `:my_tag` to the command below.
 ```bash
-$ docker tag cloudshell-image gcr.io/stackdriver-sandbox-230822/cloudshell-image
+$ docker tag cloudshell-image gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified
 ```
 
 4. Finally, push the image. It should be visible in the registry.
 ```bash
-$ docker push gcr.io/stackdriver-sandbox-230822/cloudshell-image
+$ docker push gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified
 ```
 
 See the [Google documentation for Container Registry](https://cloud.google.com/container-registry/docs/quickstart)  for more information on these steps.

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -23,19 +23,26 @@ steps:
   - |-
     git clone https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git
     cd cloud-ops-sandbox
-    # build latest image
-    docker build -t gcr.io/$PROJECT_ID/cloudshell-image:latest ./cloud-shell
-    docker push gcr.io/$PROJECT_ID/cloudshell-image:latest
-    for TAG in $(git tag); do
-        echo "checking out $$TAG"
-        git checkout $$TAG
-        # if cloud-build directory exists, build new container
-        if [[ -d "./cloud-shell" ]]; then
-            echo "building $$TAG"
-            docker build -t gcr.io/$PROJECT_ID/cloudshell-image:$$TAG ./cloud-shell
-            docker push gcr.io/$PROJECT_ID/cloudshell-image:$$TAG
-        else
-            echo "No cloud-shell directory in tag $$TAG"
-        fi
+
+    # build images in both GCR repos
+    CERTIFIED_PATH=gcr.io/$PROJECT_ID/cloudshell-image
+    UNCERTIFIED_PATH=$$CERTIFIED_PATH/uncertified
+
+    for GCR_PATH in $$CERTIFIED_PATH $$UNCERTIFIED_PATH; do
+        # build latest image
+        docker build -t $$GCR_PATH:latest ./cloud-shell
+        docker push $$GCR_PATH:latest
+        for TAG in $(git tag); do
+            echo "checking out $$TAG"
+            git checkout $$TAG
+            # if cloud-build directory exists, build new container
+            if [[ -d "./cloud-shell" ]]; then
+                echo "building $$TAG"
+                docker build -t $$GCR_PATH:$$TAG ./cloud-shell
+                docker push $$GCR_PATH:$$TAG
+            else
+                echo "No cloud-shell directory in tag $$TAG"
+            fi
+        done
     done
 logsBucket: 'gs://sandbox-cloud-build-logs'

--- a/make-release.sh
+++ b/make-release.sh
@@ -33,11 +33,11 @@ find "${REPO_ROOT}/kubernetes-manifests/loadgenerator" -name '*.yaml' -exec sed 
 
 # update README
 sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/README.md;
-sed -i -e "s/cloudshell-image:v\([0-9\.]\+\)/cloudshell-image:${NEW_VERSION}/g" ${REPO_ROOT}/README.md;
+sed -i -e "s/uncertified:v\([0-9\.]\+\)/uncertified:${NEW_VERSION}/g" ${REPO_ROOT}/README.md;
 
 # update website deployment tag
 sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/website/index.html;
-sed -i -e "s/cloudshell-image:v\([0-9\.]\+\)/cloudshell-image:${NEW_VERSION}/g" ${REPO_ROOT}/website/index.html;
+sed -i -e "s/uncertified:v\([0-9\.]\+\)/uncertified:${NEW_VERSION}/g" ${REPO_ROOT}/website/index.html;
 
 # update custom Cloud Shell image variable
 sed -i -e "s/VERSION=v\([0-9\.]\+\)/VERSION=${NEW_VERSION}/g" ${REPO_ROOT}/cloud-shell/Dockerfile;

--- a/website/index.html
+++ b/website/index.html
@@ -56,7 +56,7 @@
       <div class="steps">
         <div class="step step-1">
           <!--label>Step 1</label-->
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.3.0"
+          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.3.0"
              target="_blank">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">


### PR DESCRIPTION
We have an active issue where only the certified v0.2.0 image can be used for the existing cloud shell image path. This PR adds a new `gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified` image path, and uses that for all GCR references in the repo for now

Long term, we should move the website to the certified image, and maintain both image paths