### PR TITLE
E2e Fix: Use default GCE service account for Workload Identity

### DIFF
--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -21,6 +21,7 @@ on:
       - release/*
       - e2e*
       - loadgen_integration # will remove before merging
+      - undo-gsa # will remove before merging
   workflow_dispatch:
     # trigger through UI or API
 jobs:

--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -21,7 +21,6 @@ on:
       - release/*
       - e2e*
       - loadgen_integration # will remove before merging
-      - undo-gsa # will remove before merging
   workflow_dispatch:
     # trigger through UI or API
 jobs:

--- a/.github/workflows/e2e_scripts/clean.sh
+++ b/.github/workflows/e2e_scripts/clean.sh
@@ -26,19 +26,6 @@ export WORKDIR=$(dirname $(realpath $0))
 python3 -m pip install -r ${WORKDIR}/requirements.txt
 python3 ${WORKDIR}/cleanup_monitoring.py "projects/$PROJECT_ID"
 
-# delete service account
-GSA_EMAIL="first_run"
-while [ -n "$GSA_EMAIL" ]; do
-  GSA_EMAIL=$(gcloud iam service-accounts list \
-                    --filter="name:gke-sa" \
-                    --project $PROJECT_ID --format="value(email)")
-  if [ -n "$GSA_EMAIL" ]; then
-      echo "deleting service account"
-      gcloud iam service-accounts delete $GSA_EMAIL
-      sleep 20
-  fi
-done
-
 # delete cluster
 CLUSTER_ZONE="first_run"
 while [ -n "$CLUSTER_ZONE" ]; do

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -129,12 +129,9 @@ resource "null_resource" "current_project" {
   }
 }
 
-# Create GSA to allow K8S services to access Google APIs
-resource "google_service_account" "set_gsa" {
-  account_id   = "gke-sa"
-  display_name = "gsa"
+# Gets the default Compute Engine Service Account of GKE
+data "google_compute_default_service_account" "default" {
   project = data.google_project.project.project_id
-
   depends_on = [
     google_container_cluster.gke,
     null_resource.current_project
@@ -143,14 +140,14 @@ resource "google_service_account" "set_gsa" {
 
 # Create GSA/KSA binding: let IAM auth KSAs as a svc.id.goog member name
 resource "google_service_account_iam_binding" "set_gsa_binding" {
-  service_account_id = google_service_account.set_gsa.name
+  service_account_id = data.google_compute_default_service_account.default.name // google_service_account.set_gsa.name
   role = "roles/iam.workloadIdentityUser"
 
   members = [
     "serviceAccount:${data.google_project.project.project_id}.svc.id.goog[default/default]"
   ]
 
-  depends_on = [google_service_account.set_gsa]
+  depends_on = [data.google_compute_default_service_account.default]
 }
 
 # Annotate KSA
@@ -162,20 +159,11 @@ resource "null_resource" "annotate_ksa" {
   provisioner "local-exec" {
     command = <<EOT
       gcloud container clusters get-credentials cloud-ops-sandbox --zone ${element(random_shuffle.zone.result, 0)} --project ${data.google_project.project.project_id}
-      kubectl annotate serviceaccount --namespace default default iam.gke.io/gcp-service-account=${google_service_account.set_gsa.email}
+      kubectl annotate serviceaccount --namespace default default iam.gke.io/gcp-service-account=${data.google_compute_default_service_account.default.email}
     EOT
   }
 
   depends_on = [google_service_account_iam_binding.set_gsa_binding]
-}
-
-# Enable editor level permissions for GSA
-resource "null_resource" "set_editor" {
-  provisioner "local-exec" {
-    command = "gcloud projects add-iam-policy-binding ${data.google_project.project.project_id} --member serviceAccount:${google_service_account.set_gsa.email} --role roles/editor"
-  }
-
-  depends_on = [null_resource.annotate_ksa]
 }
 
 # Install Istio into the GKE cluster
@@ -184,7 +172,7 @@ resource "null_resource" "install_istio" {
     command = "./istio/install_istio.sh"
   }
 
-  depends_on = [null_resource.set_editor]
+  depends_on = [null_resource.annotate_ksa]
 }
 
 # Deploy microservices into GKE cluster


### PR DESCRIPTION
Improves on: #448

Changes: 
- Use default GCE service account for Workload Identity
- No longer creates a new Google service account for the GKE service account binding
- Fixes e2e test issue where we can't reapply to deleted service accounts

Note: While docs recommend we create new SAs for K8S clusters as a best practice, implementing it for Sandbox introduces unnecessary complexity to users. Agreeing with @Daniel-Sanche 's point that: "The only reason I'd hesitate is because we don't want to show bad patterns to our users, but I don't think workload identity is really in scope for what our customers would be looking at anyway."