### PR TITLE
Enable e2e latest on PRs with review requests & renovate bot configurations

### DIFF
--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -17,12 +17,13 @@ on:
   push:
     # run on pushes to master or release/*
     branches:
-      - master
-      - release/*
-      - e2e*
-      - loadgen_integration # will remove before merging
+    - master
+    - release/*
+    - e2e*
+  pull_request:
+    types: [review_requested]
   workflow_dispatch:
-    # trigger through UI or API
+  # trigger through UI or API
 jobs:
   end-to-end-latest:
     runs-on: [self-hosted, e2e-worker]

--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -17,9 +17,9 @@ on:
   push:
     # run on pushes to master or release/*
     branches:
-    - master
-    - release/*
-    - e2e*
+      - master
+      - release/*
+      - e2e*
   pull_request:
     types: [review_requested]
   workflow_dispatch:

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "pinVersions": false,
   "rebaseStalePrs": true,
   "schedule": [
-    "after 9am and before 3pm"
+    "after 9am and before 3pm every tuesday"
   ],
   "prConcurrentLimit": 5,
   "gitAuthor": null,

--- a/renovate.json
+++ b/renovate.json
@@ -2,12 +2,12 @@
   "extends": [
     "config:base"
   ],
-
   "pinVersions": false,
   "rebaseStalePrs": true,
   "schedule": [
     "after 9am and before 3pm"
   ],
+  "prConcurrentLimit": 5,
   "gitAuthor": null,
   "packageRules": [
     {
@@ -15,7 +15,11 @@
       "groupName": "linters"
     }
   ],
-  "labels": ["dependencies"],
-  "prConcurrentLimit": 5,
-  "reviewersFromCodeOwners": true
+  "reviewersFromCodeOwners": true,
+  "labels": [
+    "dependencies",
+    "type: cleanup",
+    "priority: p1",
+    "automerge"
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
   "labels": [
     "dependencies",
     "type: cleanup",
-    "priority: p1",
+    "priority: p2",
     "automerge"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   ],
   "pinVersions": false,
   "rebaseStalePrs": true,
+  "timezone": "America/Los_Angeles",
   "schedule": [
     "after 9am and before 3pm every tuesday"
   ],


### PR DESCRIPTION
Resolves #476 

**Changes:** 
- RenovateBot adds labels: `type: cleanup`, `priority: p1`, and `automerge`
- Reduces noise by rescheduling bot to run 1x week, after releases (see question1). 
- [Workflow Bot](https://github.com/nicoleczhu/workflow-controller) allows bots/whitelisted accounts to trigger CI.

**Open question:** 
1. Should we run RenovateBot 2x a week or on a different weekday? It's recommended we schedule [runs shortly after releases](https://docs.renovatebot.com/noise-reduction/#scheduling-renovate).

2. Should we let RenovateBot merge CI-passing PRs without owner approval? 
