### PR TITLE
Use certified image again

### DIFF
--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -35,9 +35,8 @@ jobs:
       id: cloud_build
       run: |
         set -x
-        run_info=$(gcloud beta builds submit --config cloud-shell/cloudbuild.yaml --async)
-        # capture run id (format: xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx)
-        run_id=$(echo $run_info |   grep -o "\([0-9,a-z]\+-\)\{4\}[0-9,a-z]\+")
+        run_id=$(gcloud builds submit \
+            --config cloud-shell/cloudbuild.yaml --asynic --format="value(id)")
         echo ::set-output name=run_id::${run_id}
     - name: Display Logs
       continue-on-error: true

--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -36,7 +36,8 @@ jobs:
       run: |
         set -x
         run_info=$(gcloud beta builds submit --config cloud-shell/cloudbuild.yaml --async)
-        run_id=$(echo $run_info |  awk '{print $1}' | tail -n 1)
+        # capture run id (format: xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx)
+        run_id=$(echo $run_info |   grep -o "\([0-9,a-z]\+-\)\{4\}[0-9,a-z]\+")
         echo ::set-output name=run_id::${run_id}
     - name: Display Logs
       continue-on-error: true

--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Run Cloud Build Trigger
       id: cloud_build
       run: |
+        set -x
         run_info=$(gcloud beta builds submit --config cloud-shell/cloudbuild.yaml --async)
         run_id=$(echo $run_info |  awk '{print $1}' | tail -n 1)
         echo ::set-output name=run_id::${run_id}

--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         set -x
         run_id=$(gcloud builds submit \
-            --config cloud-shell/cloudbuild.yaml --asynic --format="value(id)")
+            --config cloud-shell/cloudbuild.yaml --async --format="value(id)")
         echo ::set-output name=run_id::${run_id}
     - name: Display Logs
       continue-on-error: true

--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Run Cloud Build Trigger
       id: cloud_build
       run: |
-        run_info=$(gcloud beta builds triggers run --branch=master Build-CloudShell-Image)
-        run_id=$(echo $run_info | grep -oP "id: \K(\w+-){4}\w+")
+        run_info=$(gcloud beta builds submit --config cloud-shell/cloudbuild.yaml --async)
+        run_id=$(echo $run_info |  awk '{print $1}' | tail -n 1)
         echo ::set-output name=run_id::${run_id}
     - name: Display Logs
       continue-on-error: true

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -30,7 +30,7 @@ steps:
     # build latest image
     docker build -t $$UNCERTIFIED_PATH:latest ./cloud-shell
     docker push $$UNCERTIFIED_PATH:latest
-    for TAG in $(git tag); do
+    for TAG in $(git tag | sort -V); do
         echo "checking out $$TAG"
         git checkout $$TAG
         # if cloud-build directory exists, build new container

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -24,25 +24,32 @@ steps:
     git clone https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git
     cd cloud-ops-sandbox
 
-    # build images in both GCR repos
-    CERTIFIED_PATH=gcr.io/$PROJECT_ID/cloudshell-image
-    UNCERTIFIED_PATH=$$CERTIFIED_PATH/uncertified
-
-    for GCR_PATH in $$CERTIFIED_PATH $$UNCERTIFIED_PATH; do
-        # build latest image
-        docker build -t $$GCR_PATH:latest ./cloud-shell
-        docker push $$GCR_PATH:latest
-        for TAG in $(git tag); do
-            echo "checking out $$TAG"
-            git checkout $$TAG
-            # if cloud-build directory exists, build new container
-            if [[ -d "./cloud-shell" ]]; then
-                echo "building $$TAG"
-                docker build -t $$GCR_PATH:$$TAG ./cloud-shell
-                docker push $$GCR_PATH:$$TAG
-            else
-                echo "No cloud-shell directory in tag $$TAG"
-            fi
-        done
+    # update uncertified images
+    # build images for each releases, and repo HEAD
+    UNCERTIFIED_PATH=gcr.io/$PROJECT_ID/cloudshell-image/uncertified
+    # build latest image
+    docker build -t $$UNCERTIFIED_PATH:latest ./cloud-shell
+    docker push $$UNCERTIFIED_PATH:latest
+    for TAG in $(git tag); do
+        echo "checking out $$TAG"
+        git checkout $$TAG
+        # if cloud-build directory exists, build new container
+        if [[ -d "./cloud-shell" ]]; then
+            echo "building $$TAG"
+            docker build -t $$UNCERTIFIED_PATH:$$TAG ./cloud-shell
+            docker push $$UNCERTIFIED_PATH:$$TAG
+        else
+            echo "No cloud-shell directory in tag $$TAG"
+        fi
     done
+
+    # update certified image
+    # build image using latest release
+    CERTIFIED_PATH=gcr.io/$PROJECT_ID/cloudshell-image
+    LATEST_TAG=$(git tag | grep "v[0-9]*\.[0-9]*\.[0-9]*" | sort -V | tail -n 1)
+    git checkout $$LATEST_TAG
+    docker build -t $$CERTIFIED_PATH:latest ./cloud-shell
+    docker build -t $$CERTIFIED_PATH:$$LATEST_TAG ./cloud-shell
+    docker push $$CERTIFIED_PATH:latest
+    docker push $$CERTIFIED_PATH:$$LATEST_TAG
 logsBucket: 'gs://sandbox-cloud-build-logs'

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -49,5 +49,7 @@ steps:
     LATEST_TAG=$(git tag | grep "v[0-9]*\.[0-9]*\.[0-9]*" | sort -V | tail -n 1)
     git checkout $$LATEST_TAG
     docker build -t $$CERTIFIED_PATH:latest ./cloud-shell
+    docker build -t $$CERTIFIED_PATH:$$LATEST_TAG ./cloud-shell
     docker push $$CERTIFIED_PATH:latest
+    docker push $$CERTIFIED_PATH:$$LATEST_TAG
 logsBucket: 'gs://sandbox-cloud-build-logs'

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -49,7 +49,5 @@ steps:
     LATEST_TAG=$(git tag | grep "v[0-9]*\.[0-9]*\.[0-9]*" | sort -V | tail -n 1)
     git checkout $$LATEST_TAG
     docker build -t $$CERTIFIED_PATH:latest ./cloud-shell
-    docker build -t $$CERTIFIED_PATH:$$LATEST_TAG ./cloud-shell
     docker push $$CERTIFIED_PATH:latest
-    docker push $$CERTIFIED_PATH:$$LATEST_TAG
 logsBucket: 'gs://sandbox-cloud-build-logs'

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
     # update certified image
     # build image using latest release
     CERTIFIED_PATH=gcr.io/$PROJECT_ID/cloudshell-image
-    LATEST_TAG=$(git tag | grep "v[0-9]*\.[0-9]*\.[0-9]*" | sort -V | tail -n 1)
+    LATEST_TAG=$(git describe --abbrev=0 --tags)
     git checkout $$LATEST_TAG
     docker build -t $$CERTIFIED_PATH:latest ./cloud-shell
     docker build -t $$CERTIFIED_PATH:$$LATEST_TAG ./cloud-shell

--- a/make-release.sh
+++ b/make-release.sh
@@ -37,7 +37,6 @@ sed -i -e "s/uncertified:v\([0-9\.]\+\)/uncertified:${NEW_VERSION}/g" ${REPO_ROO
 
 # update website deployment tag
 sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/website/index.html;
-sed -i -e "s/cloudshell-image:v\([0-9\.]\+\)/cloudshell-image:${NEW_VERSION}/g" ${REPO_ROOT}/website/index.html;
 
 # update custom Cloud Shell image variable
 sed -i -e "s/VERSION=v\([0-9\.]\+\)/VERSION=${NEW_VERSION}/g" ${REPO_ROOT}/cloud-shell/Dockerfile;

--- a/make-release.sh
+++ b/make-release.sh
@@ -37,7 +37,7 @@ sed -i -e "s/uncertified:v\([0-9\.]\+\)/uncertified:${NEW_VERSION}/g" ${REPO_ROO
 
 # update website deployment tag
 sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/website/index.html;
-sed -i -e "s/uncertified:v\([0-9\.]\+\)/uncertified:${NEW_VERSION}/g" ${REPO_ROOT}/website/index.html;
+sed -i -e "s/cloudshell-image:v\([0-9\.]\+\)/cloudshell-image:${NEW_VERSION}/g" ${REPO_ROOT}/website/index.html;
 
 # update custom Cloud Shell image variable
 sed -i -e "s/VERSION=v\([0-9\.]\+\)/VERSION=${NEW_VERSION}/g" ${REPO_ROOT}/cloud-shell/Dockerfile;

--- a/website/index.html
+++ b/website/index.html
@@ -56,7 +56,7 @@
       <div class="steps">
         <div class="step step-1">
           <!--label>Step 1</label-->
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.3.0"
+          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:latest"
              target="_blank">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">

--- a/website/index.html
+++ b/website/index.html
@@ -56,7 +56,7 @@
       <div class="steps">
         <div class="step step-1">
           <!--label>Step 1</label-->
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.3.0"
+          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.3.0"
              target="_blank">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">


### PR DESCRIPTION
We previously started using uncertified cloud shell images, when we discovered certified images force you to use a single version. Now that `cloudshell-image:latest` has been certified, we can go back to using that one on the website.

I updated the "rebuild cloudshell" action to keep the certified image up to date with the latest release. The uncertified images will continue to be built for each previous release, and I suggest we still use those for testing