### PR TITLE
Feat: customize how labeler bot detects languages with user config file

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Disable label by Drift product
 product: false
 language:

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -25,7 +25,7 @@ language:
   labelprefix: 'lang: '
   # To re-map extension to languages
   extensions:
-    yaml: ['tf']
+    manifest: ['tf']
     typescript: ['ts']
   # To map languages based on project directory structure:
   paths:

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,35 @@
+# Disable label by Drift product
+product: false
+language:
+  # Disable issue labeling (not accurate)
+  issue: false
+  # Enable pr labeling
+  pullrequest: true
+  labelprefix: 'lang: '
+  # To re-map extension to languages
+  extensions:
+    JSON: ['JSON']
+    typescript: ['ts']
+  # To map languages based on project directory structure:
+  paths:
+    src:
+      frontend: 'go'
+      cartservice: 'c#'
+      productcatalogservice: 'go'
+      currencyservice: 'javascript'
+      paymentservice: 'javascript'
+      shippingservice: 'go'
+      emailservice: 'python'
+      checkoutservice: 'go'
+      recommendationservice: 'python'
+      adservice: 'java'
+      loadgenerator: 'python'
+    tests:
+      # To designate the default language for a subdirectory use '.'
+      .: 'python'
+      # More specific path designations will overwrite the default
+      cartservice: 'c#'
+      ratingservice: 'python'
+    website:
+      .: 'javascript'
+      images: 'svg'

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # Config file for Label Bot
+# TODO: update this with Yoshi repo later
+# Default settings: https://github.com/nicoleczhu/language-labeler/blob/b1e6adb3d1dbc02dc34ea6caf42b50f1f29a2450/src/lang-label.ts#L5
 # Disable label by Drift product
 product: false
 language:
@@ -23,13 +25,13 @@ language:
   labelprefix: 'lang: '
   # To re-map extension to languages
   extensions:
-    terraform: ['tf']
+    yaml: ['tf']
     typescript: ['ts']
   # To map languages based on project directory structure:
   paths:
     src:
       frontend: 'go'
-      cartservice: 'c#'
+      cartservice: 'dotnet'
       productcatalogservice: 'go'
       currencyservice: 'javascript'
       paymentservice: 'javascript'
@@ -39,13 +41,11 @@ language:
       recommendationservice: 'python'
       adservice: 'java'
       loadgenerator: 'python'
-    terraform:
-      # To designate the default language for a subdirectory use '.'
-      .: 'terraform'
     tests:
+      # To designate the default language for a subdirectory use '.'
       .: 'python'
       # More specific path designations will overwrite the default
-      cartservice: 'c#'
+      cartservice: 'dotnet'
       ratingservice: 'python'
     website:
       .: 'javascript'

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Config file for Label Bot
 # Disable label by Drift product
 product: false
 language:
@@ -22,7 +23,7 @@ language:
   labelprefix: 'lang: '
   # To re-map extension to languages
   extensions:
-    JSON: ['JSON']
+    terraform: ['tf']
     typescript: ['ts']
   # To map languages based on project directory structure:
   paths:
@@ -38,8 +39,10 @@ language:
       recommendationservice: 'python'
       adservice: 'java'
       loadgenerator: 'python'
-    tests:
+    terraform:
       # To designate the default language for a subdirectory use '.'
+      .: 'terraform'
+    tests:
       .: 'python'
       # More specific path designations will overwrite the default
       cartservice: 'c#'


### PR DESCRIPTION
Main changes fyi: 
- Language labeling is turned off by default (until we add this config file)
- Can config languages based on project directory structure, e.g. /sr/emailservice -> "lang: python"
- Can config custom file extension to language mappings, e.g. "filename.ts" -> "lang: js"
- Can config label copy e.g. "language: python" instead of "lang: python" 
- I turned off labeling issues since it's hit and miss and will take a lot more work to get accurate.
- Config file is optional

A few things to discuss: 
1. How do we want to label repos like /terraform, /cloudshell. Or not label them? @Daniel-Sanche 
2. Do we want to label with as many languages as possible, or a whitelisted set of languages? I can add a `verbose` config to enable/disable this
3. Are you ok with the current set of label names? e.g. `javascript` instead of `js` or `node.js`

Note: Bot is still running on my deployment atm.