### PR TITLE
Fix: istio/gke version conflict by unpinning gke version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,19 @@ ZONE=us-west1-a
 CLUSTER=cloud-ops-sandbox-${USER}
 
 cluster: check-env
+	gcloud services enable container.googleapis.com
 	EXISTING_CLUSTER=`gcloud container clusters list --zone=${ZONE} --format="value(name)" --filter="name:${CLUSTER}"`
 	if [ "${EXISTING_CLUSTER}" != "" ]; then \
     	gcloud container clusters delete ${CLUSTER} --project=${PROJECT_ID} --zone=${ZONE} --quiet; \
 	fi
-	
+
 	gcloud beta container clusters create ${CLUSTER} \
 		--project=${PROJECT_ID} --zone=${ZONE} \
 		--machine-type=n1-standard-2 --num-nodes=4 \
 		--enable-stackdriver-kubernetes \
 		--scopes https://www.googleapis.com/auth/cloud-platform
-	#cd ./terraform/istio && \
-	#./install_istio.sh
+	cd ./terraform/istio && \
+	./install_istio.sh
 	skaffold run --default-repo=gcr.io/${PROJECT_ID}/sandbox -l skaffold.dev/run-id=${CLUSTER}-${PROJECT_ID}-${ZONE}
 
 deploy: check-env

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -43,6 +43,10 @@ resource "google_container_cluster" "gke" {
   provider = google-beta
   project = data.google_project.project.project_id
 
+  # Set minimum GKE version to stable release since Terraform currently defaults to v1.15
+  # This can be unpinned once Terraform defaults to the correct GKE stable release
+  min_master_version = "1.16.13-gke.401"
+
   # Here's how you specify the name
   name = "cloud-ops-sandbox"
 

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -42,7 +42,6 @@ resource "random_shuffle" "zone" {
 resource "google_container_cluster" "gke" {
   provider = google-beta
   project = data.google_project.project.project_id
-  min_master_version = "1.16.13-gke.401"
 
   # Here's how you specify the name
   name = "cloud-ops-sandbox"

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -43,10 +43,6 @@ resource "google_container_cluster" "gke" {
   provider = google-beta
   project = data.google_project.project.project_id
 
-  # Set minimum GKE version to stable release since Terraform currently defaults to v1.15
-  # This can be unpinned once Terraform defaults to the correct GKE stable release
-  min_master_version = "1.16.13-gke.401"
-
   # Here's how you specify the name
   name = "cloud-ops-sandbox"
 


### PR DESCRIPTION
I just checked today, issue #482 doesn't happen anymore with the GKE's [Oct 2 release](https://cloud.google.com/kubernetes-engine/docs/release-notes) where: "Version 1.16.13-gke.401 is the new default version for clusters with no & stable channels."
