### PR TITLE
Fix sandboxctl create

### DIFF
--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -127,13 +127,16 @@ def create():
     os.chdir(os.path.abspath(sys.path[0]))
     create_command = "../terraform/install.sh"
     os.setpgrp()
+    complete = False
     try:
         # run install.sh in a background shell
         process = subprocess.Popen([create_command], bufsize=0, shell=True)
         process.communicate()
+        complete = True
     finally:
         # kill background process if script is terminated
-        os.killpg(0, signal.SIGKILL)
+        if not complete:
+            os.killpg(0, signal.SIGTERM)
 
 @cli.command()
 def destroy():

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -124,7 +124,12 @@ def create():
     """Create a new sandbox"""
     os.chdir(os.path.abspath(sys.path[0]))
     create_command = "../terraform/install.sh"
-    Recipe._run_command(create_command)
+    os.setpgrp()
+    try:
+        process = subprocess.Popen([create_command], bufsize=0, shell=True)
+        process.communicate()
+    finally:
+        os.killpg(0, signall.SIGKILL)
 
 @cli.command()
 def destroy():

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -128,9 +128,11 @@ def create():
     create_command = "../terraform/install.sh"
     os.setpgrp()
     try:
+        # run install.sh in a background shell
         process = subprocess.Popen([create_command], bufsize=0, shell=True)
         process.communicate()
     finally:
+        # kill background process if script is terminated
         os.killpg(0, signal.SIGKILL)
 
 @cli.command()

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -28,6 +28,8 @@ from enum import Enum
 import logging
 import os
 import sys
+import signal
+import subprocess
 from os.path import dirname, abspath
 from pkgutil import iter_modules
 from pathlib import Path
@@ -129,7 +131,7 @@ def create():
         process = subprocess.Popen([create_command], bufsize=0, shell=True)
         process.communicate()
     finally:
-        os.killpg(0, signall.SIGKILL)
+        os.killpg(0, signal.SIGKILL)
 
 @cli.command()
 def destroy():


### PR DESCRIPTION
As part of our bugbash, we discovered an issue where `sandboxctl create` wouldn't show the output from `terraform apply`. This PR should fix that issue

[Click to Deploy](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=fix-install&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:latest)