### PR TITLE
Fix release script and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 
 Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
 
-[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.3.0)
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.3.0&cloudshell_tutorial=docs/tutorial.md)
 
 __Note__: If installation stops due to billing account errors, set up the billing account and type: `sandboxctl create`.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 
 Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
 
-[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.3.0)
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.3.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.3.0)
 
 __Note__: If installation stops due to billing account errors, set up the billing account and type: `sandboxctl create`.
 

--- a/make-release.sh
+++ b/make-release.sh
@@ -29,7 +29,7 @@ fi
 
 # temporarily pin manifests to :$NEW_VERSION
 find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s/:latest/:${NEW_VERSION}/g" {} \;
-find "${REPO_ROOT}/kubernetes-manifests/loadgenerator" -name '*.yaml' -exec sed -i -e "s/:latest/:${NEW_VERSION}/g" {} \;
+find "${REPO_ROOT}/loadgenerator-manifests" -name '*.yaml' -exec sed -i -e "s/:latest/:${NEW_VERSION}/g" {} \;
 
 # update README
 sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/README.md;
@@ -54,7 +54,7 @@ else
     # create release commit
     git checkout -b "release/${NEW_VERSION}"
     git add "${REPO_ROOT}/kubernetes-manifests/*.yaml"
-    git add "${REPO_ROOT}/kubernetes-manifests/loadgenerator/*.yaml"
+    git add "${REPO_ROOT}/loadgenerator-manifests/*.yaml"
     git add "${REPO_ROOT}/website/index.html"
     git add "${REPO_ROOT}/README.md"
     git add "${REPO_ROOT}/cloud-shell/Dockerfile"
@@ -67,12 +67,12 @@ else
     # change back manifests to :latest
     find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s/:${NEW_VERSION}/:latest/g" {} \;
     git add "${REPO_ROOT}/kubernetes-manifests/*.yaml"
-    git add "${REPO_ROOT}/kubernetes-manifests/loadgenerator/*.yaml"
+    git add "${REPO_ROOT}/loadgenerator-manifests/*.yaml"
 
     # change back telemetry Pub/Sub topic to "Test" topic
     sed -i -e "s/topic_id = \"${PROD_TOPIC}\"/topic_id = \"${TEST_TOPIC}\"/g" ${REPO_ROOT}/terraform/telemetry.py;
     git add "${REPO_ROOT}/terraform/telemetry.py"
-    
+
     git commit -m "revert images to latest and telemetry pipeline to 'test'"
 
     # if no-push mode, exit without pushing git branch or tags to origin


### PR DESCRIPTION
A couple small fixes before the release:
- the release script was using the wrong path for the load generator manifests
- the README didn't include the cloud shell tutorial, and was still using terraform as the working directory instead of the repo root