### PR TITLE
Fix locust

### DIFF
--- a/loadgenerator-manifests/loadgenerator.yaml
+++ b/loadgenerator-manifests/loadgenerator.yaml
@@ -16,7 +16,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: loadgenerator-main
+  name: loadgenerator
 spec:
   replicas: 1
   selector:

--- a/loadgenerator-manifests/loadgenerator.yaml
+++ b/loadgenerator-manifests/loadgenerator.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: LOCUST_MODE
-              value: master
+              value: standalone
             - name: LOCUST_TASK
               value: basic_locustfile.py
             - name: TARGET_HOST
@@ -47,45 +47,6 @@ spec:
             - name: loc-master-web
               containerPort: 8089
               protocol: TCP
-            - name: loc-master-p1
-              containerPort: 5557
-              protocol: TCP
-            - name: loc-master-p2
-              containerPort: 5558
-              protocol: TCP
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: loadgenerator-worker
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: loadgenerator
-      mode: worker
-  template:
-    metadata:
-      labels:
-        app: loadgenerator
-        mode: worker
-    spec:
-      containers:
-        - name: locust-worker
-          image: gcr.io/stackdriver-sandbox-230822/sandbox/loadgenerator/gke:latest
-          imagePullPolicy: Always
-          env:
-            - name: LOCUST_MODE
-              value: worker
-            - name: LOCUST_MASTER
-              value: loadgenerator
-            - name: LOCUST_TASK
-              value: basic_locustfile.py
-            - name: TARGET_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: address-config
-                  key: FRONTEND_ADDR
 ---
 kind: Service
 apiVersion: v1
@@ -99,14 +60,6 @@ spec:
       targetPort: loc-master-web
       protocol: TCP
       name: loc-master-web
-    - port: 5557
-      targetPort: loc-master-p1
-      protocol: TCP
-      name: loc-master-p1
-    - port: 5558
-      targetPort: loc-master-p2
-      protocol: TCP
-      name: loc-master-p2
   selector:
     app: loadgenerator
     mode: master

--- a/loadgenerator-manifests/loadgenerator.yaml
+++ b/loadgenerator-manifests/loadgenerator.yaml
@@ -56,7 +56,7 @@ metadata:
     app: loadgenerator
 spec:
   ports:
-    - port: 8089
+    - port: 80
       targetPort: loc-master-web
       protocol: TCP
       name: loc-master-web

--- a/src/loadgenerator/locust-tasks/basic_locustfile.py
+++ b/src/loadgenerator/locust-tasks/basic_locustfile.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import random
-from locust import HttpUser, TaskSet
+from locust import task, HttpUser, TaskSet
 
 products = [
     '0PUK6V6EV0',
@@ -38,22 +38,28 @@ currencies = [
 
 # Define specific frontend actions.
 
+@task
 def index(l):
     l.client.get("/")
 
+@task
 def setCurrency(l):
     l.client.post("/setCurrency",
         {'currency_code': random.choice(currencies)})
 
+@task
 def browseProduct(l):
     l.client.get("/product/" + random.choice(products))
 
+@task
 def viewCart(l):
     l.client.get("/cart")
 
+@task
 def emptyCart(l):
     l.client.post("/cart/empty")
 
+@task
 def addToCart(l):
     product = random.choice(products)
     l.client.get("/product/" + product)
@@ -61,6 +67,7 @@ def addToCart(l):
         'product_id': product,
         'quantity': random.choice([1,2,3,4,5,10])})
 
+@task
 def checkout(l):
     addToCart(l)
     l.client.post("/cart/checkout", {
@@ -117,7 +124,7 @@ class PurchasingUser(HttpUser):
     '''
     User that browses products, adds to cart, and purchases via checkout.
     '''
-    task_set = PurchasingBehavior
+    tasks = [PurchasingBehavior]
     min_wait = 1000
     max_wait = 10000
 
@@ -125,7 +132,7 @@ class WishlistUser(HttpUser):
     '''
     User that browses products, adds to cart, empties cart, but never purchases.
     '''
-    task_set = WishlistBehavior
+    tasks = [WishlistBehavior]
     min_wait = 1000
     max_wait = 10000
 
@@ -133,6 +140,6 @@ class BrowsingUser(HttpUser):
     '''
     User that only browses products.
     '''
-    task_set = BrowsingBehavior
+    tasks = [BrowsingBehavior]
     min_wait = 1000
     max_wait = 10000

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -121,8 +121,9 @@ def loadgen(traffic_pattern):
     Recipe._run_command(delete_pods_command)
     print(f'Loadgenerator deployed using {traffic_pattern} pattern')
     ip_addr, _ = Recipe._run_command(get_ip_command)
+    ip_addr = ip_addr.decode('utf-8').strip("'")
     if ip_addr:
-        print(f'Loadgenerator web UI: http://{ip_addr}')
+        print(f"Loadgenerator web UI: http://{ip_addr.decode('utf-8')}")
     Recipe._auth_cluster('APP')
 
 @cli.command()

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -123,7 +123,7 @@ def loadgen(traffic_pattern):
     ip_addr, _ = Recipe._run_command(get_ip_command)
     ip_addr = ip_addr.decode('utf-8').strip("'")
     if ip_addr:
-        print(f"Loadgenerator web UI: http://{ip_addr.decode('utf-8')}")
+        print(f"Loadgenerator web UI: http://{ip_addr}")
     Recipe._auth_cluster('APP')
 
 @cli.command()

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -110,15 +110,19 @@ def sre_recipes(action, recipe_name):
 def loadgen(traffic_pattern):
     """Change traffic patterns for the loadgenerator service"""
     Recipe._auth_cluster('LOADGEN')
-    set_env_commands = ["kubectl set env deployment/loadgenerator-"\
-                            f"{mode} LOCUST_TASK={traffic_pattern}_locustfile.py" \
-                            for mode in ['main', 'worker']]
-    print('Redeploying Loadgenerator...')
-    for cmd in set_env_commands:
-        Recipe._run_command(cmd)
+    get_ip_command = "kubectl get service loadgenerator -o "\
+                        "jsonpath='{.status.loadBalancer.ingress[0].ip}'"
+    set_env_command = "kubectl set env deployment/loadgenerator "\
+                        f"LOCUST_TASK={traffic_pattern}_locustfile.py"
     delete_pods_command = "kubectl delete pods -l app=loadgenerator"
+
+    print('Redeploying Loadgenerator...')
+    Recipe._run_command(set_env_command)
     Recipe._run_command(delete_pods_command)
     print(f'Loadgenerator deployed using {traffic_pattern} pattern')
+    ip_addr, _ = Recipe._run_command(get_ip_command)
+    if ip_addr:
+        print(f'Loadgenerator web UI: http://{ip_addr}:8089')
     Recipe._auth_cluster('APP')
 
 @cli.command()

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -122,7 +122,7 @@ def loadgen(traffic_pattern):
     print(f'Loadgenerator deployed using {traffic_pattern} pattern')
     ip_addr, _ = Recipe._run_command(get_ip_command)
     if ip_addr:
-        print(f'Loadgenerator web UI: http://{ip_addr}:8089')
+        print(f'Loadgenerator web UI: http://{ip_addr}')
     Recipe._auth_cluster('APP')
 
 @cli.command()

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -281,10 +281,9 @@ loadGen() {
   gcloud container clusters get-credentials loadgenerator --zone "$LOADGEN_ZONE"
   kubectx loadgenerator=.
 
-  LOCUST_PORT="8089"
   # find the IP of the load generator web interface
   TRIES=0
-  while [[ $(curl -sL -w "%{http_code}"  "http://$loadgen_ip:$LOCUST_PORT" -o /dev/null --max-time 1) -ne 200  && \
+  while [[ $(curl -sL -w "%{http_code}"  "http://$loadgen_ip" -o /dev/null --max-time 1) -ne 200  && \
       "${TRIES}" -lt 20  ]]; do
     log "waiting for load generator instance..."
     sleep 10
@@ -298,7 +297,6 @@ loadGen() {
 }
 
 displaySuccessMessage() {
-    LOCUST_PORT="8089"
     gcp_path="https://console.cloud.google.com"
     if [[ -n "${project_id}" ]]; then
         gcp_kubernetes_path="$gcp_path/kubernetes/workload?project=$project_id"
@@ -306,7 +304,7 @@ displaySuccessMessage() {
     fi
 
     if [[ -n "${loadgen_ip}" ]]; then
-        loadgen_addr="http://$loadgen_ip:$LOCUST_PORT"
+        loadgen_addr="http://$loadgen_ip"
         sendTelemetry $project_id loadgen-available
     else
         loadgen_addr="[not found]"

--- a/terraform/loadgen/00_loadgen.tf
+++ b/terraform/loadgen/00_loadgen.tf
@@ -141,7 +141,7 @@ resource "null_resource" "deploy_services" {
 # We wait for the load generator to become available on kubernetes
 resource "null_resource" "delay" {
   provisioner "local-exec" {
-    command = "kubectl wait --for=condition=available --timeout=600s deployment/loadgenerator-main"
+    command = "kubectl wait --for=condition=available --timeout=600s deployment/loadgenerator"
   }
 
   triggers = {

--- a/tests/provisioning/loadgen_test.py
+++ b/tests/provisioning/loadgen_test.py
@@ -59,7 +59,7 @@ class TestLoadGenerator(unittest.TestCase):
         command = ("kubectl get service loadgenerator --context=%s -o jsonpath='{.status.loadBalancer.ingress[0].ip}'" % TestLoadGenerator.context)
         result = subprocess.run(split(command), encoding='utf-8', capture_output=True)
         loadgen_ip = result.stdout.replace('\n', '')
-        url = 'http://{0}:8089'.format(loadgen_ip)
+        url = 'http://{0}'.format(loadgen_ip)
         self.assertTrue(urllib.request.urlopen(url).getcode() == 200)
 
     def testDifferentZone(self):


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/505

- We were seeing an exception thrown on the basic loadgenerator. This PR fixes that issue.
- I changed the loadgenerator from distributed to standalone mode to make it easier to deal with
- I changed the loadgenerator service to use the standard port 80 instead of 8089
- `sandboxctl loadgen` prints the loadgenrator web address after making changes

[Deploy in Cloud Shell](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=fix-locust&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.4.0&cloudshell_tutorial=docs/tutorial.md)