### PR TITLE
ci: run e2e on prs to master & set renovate reviewer to nicole

### DIFF
--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -22,7 +22,8 @@ on:
       - e2e*
       - step-pattern
   pull_request:
-    types: [review_requested]
+    branches:
+      - master
   workflow_dispatch:
   # trigger through UI or API
 jobs:

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
       "groupName": "linters"
     }
   ],
-  "reviewersFromCodeOwners": true,
+  "reviewers": ["nicoleczhu"],
   "labels": [
     "dependencies",
     "type: cleanup",


### PR DESCRIPTION
Since we require a reviewer for all PRs, running e2e on branch:master, rather than review_requested, makes more sense. 
Also update renovatebot to request reviews from me weekly.