### PR TITLE
Disable recipe1

### DIFF
--- a/sre-recipes/recipe.py
+++ b/sre-recipes/recipe.py
@@ -30,7 +30,11 @@ class Recipe(abc.ABC):
 
     @abc.abstractmethod
     def get_name(self):
-        """ Returns the name of the recipe"""
+        """Returns the name of the recipe"""
+
+    def is_active(self):
+        """Determines whether the recipe shows up in sandboxctl"""
+        return True
 
     @abc.abstractmethod
     def break_service(self):

--- a/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
+++ b/sre-recipes/recipes/encoding_recipe/encoding_recipe.py
@@ -32,6 +32,11 @@ class EncodingRecipe(Recipe):
     def get_name(self):
         return self.name
 
+    def is_active(self):
+        # recipe temporarily disabled until it is easier to solve
+        # TODO: improve and re-enable recipe
+        return False
+
     def deploy_state(self, state):
         """
         Sets an environment variable ENCODE_EMAIL to given state

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -51,8 +51,9 @@ def get_valid_recipes(attributes):
             try:
                 recipe_obj = attribute()
                 name = recipe_obj.get_name()
-                recipe_objs[name] = recipe_obj
-                recipe_num += 1
+                if recipe_obj.is_active():
+                    recipe_objs[name] = recipe_obj
+                    recipe_num += 1
             except TypeError:
                 logging.warning('%s needs to implement all abstract methods', \
                     attribute_name)


### PR DESCRIPTION
Removing sre recipe 1, as discussed in our meeting.

I added a new method to all recipes called `is_active()`. If overridden to return False in a subclass, that recipe won't appear in sandboxctl