### PR TITLE
ci: moved project_IDs from secrets to env variable

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,7 @@ workloads run using [GitHub self-hosted runners](https://help.github.com/en/acti
     - `Cloud Build Editor`
     - `read permissions on GCS bucket holding cloud build logs`
     - `write permissons on GCS bucket holding GCR images`
-  - requires `PROJECT_ID` to be set properly in the [repo's secrets](https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/settings/secrets)
+  - requires `PROJECT_ID` to be set properly as an environment variable
 - `e2e-worker`
   - end to end test worker
   - requires the following permissions on the end-to-end test project:
@@ -38,7 +38,7 @@ workloads run using [GitHub self-hosted runners](https://help.github.com/en/acti
     - `logging admin`
     - `service account user`
     - `storage admin` access to the GCR and terraform data buckets
-  - requires `E2E_PROJECT_ID` to be set properly in the [repo's secrets](https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/settings/secrets)
+  - requires `E2E_PROJECT_ID` to be set properly as an environment variable
 
 ---
 ## Workflows

--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -26,6 +26,8 @@ on:
       - master
   workflow_dispatch:
   # trigger through UI or API
+env:
+  PROJECT_ID: stackdriver-sandbox-e2e
 jobs:
   end-to-end-latest:
     runs-on: [self-hosted, e2e-worker]
@@ -41,20 +43,16 @@ jobs:
         set -x
         skaffold config set --global local-cluster false
         # tag with git hash
-        skaffold build --default-repo=gcr.io/$PROJECT_ID/tests \
+        skaffold build --default-repo=gcr.io/${{ env.PROJECT_ID }}/tests \
                        --tag=$GITHUB_SHA
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Build Load Generator
       run: |
         set -x
         gcloud auth configure-docker --quiet
         # push latest load generator to test image repository
-        IMAGE_PATH=gcr.io/$PROJECT_ID/tests/gcr.io/stackdriver-sandbox-230822/sandbox/loadgenerator/gke:$GITHUB_SHA
+        IMAGE_PATH=gcr.io/${{ env.PROJECT_ID }}/tests/gcr.io/stackdriver-sandbox-230822/sandbox/loadgenerator/gke:$GITHUB_SHA
         docker build -t $IMAGE_PATH ./src/loadgenerator
         docker push $IMAGE_PATH
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Rewrite Manifests
       run: |
         set -x
@@ -71,33 +69,29 @@ jobs:
         docker build -t test-cloud-shell:$GITHUB_SHA ./cloud-shell
         # run install script
         docker run --rm \
-          -e project_id=$PROJECT_ID \
+          -e project_id=${{ env.PROJECT_ID }} \
           -e skip_workspace_prompt=1 \
           -e service_wait=1 \
           -v ~/.config:/root/.config \
           -v `pwd`:/sandbox-shared \
           --entrypoint /sandbox-shared/.github/workflows/e2e_scripts/run_install.sh \
           test-cloud-shell:$GITHUB_SHA
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Run Provisioning Test
       timeout-minutes: 30
       run: |
         set -x
         # get cluster zones
-        CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project $PROJECT_ID --format="value(zone)")
-        LOADGEN_ZONE=$(gcloud container clusters list --filter="name:loadgenerator" --project $PROJECT_ID --format="value(zone)")
+        CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project ${{ env.PROJECT_ID }} --format="value(zone)")
+        LOADGEN_ZONE=$(gcloud container clusters list --filter="name:loadgenerator" --project ${{ env.PROJECT_ID }} --format="value(zone)")
         # build provisioning test image
         docker build -t test-provisioning:$GITHUB_SHA tests/provisioning/.
         # run provisioning tests
         docker run --rm \
-          -e GOOGLE_CLOUD_PROJECT=$PROJECT_ID \
+          -e GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }} \
           -e ZONE=$CLUSTER_ZONE \
           -e LOADGEN_ZONE=$LOADGEN_ZONE \
           -v ~/.config:/root/.config \
           test-provisioning:$GITHUB_SHA
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID }}
     - name: Run Monitoring Integration Tests
       timeout-minutes: 30
       run: |
@@ -105,27 +99,23 @@ jobs:
         # install dependencies
         python3 -m pip install -r tests/requirements.txt
         # authenticate cluster
-        CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project $PROJECT_ID --format="value(zone)")
+        CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project ${{ env.PROJECT_ID }} --format="value(zone)")
         gcloud container clusters get-credentials cloud-ops-sandbox --zone "$CLUSTER_ZONE"
         # run tests
-        python3 tests/monitoring_integration_test.py $PROJECT_ID
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
+        python3 tests/monitoring_integration_test.py ${{ env.PROJECT_ID }}
     - name: Test Using Existing Project
       timeout-minutes: 30
       run: |
         set -x
         # run install script
         docker run --rm \
-          -e project_id=$PROJECT_ID \
+          -e project_id=${{ env.PROJECT_ID }} \
           -e skip_workspace_prompt=1 \
           -e service_wait=1 \
           -v ~/.config:/root/.config \
           -v `pwd`:/sandbox-shared \
           --entrypoint /sandbox-shared/.github/workflows/e2e_scripts/run_install.sh \
           test-cloud-shell:$GITHUB_SHA
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Clean Project State
       if: ${{ always()  }}
       timeout-minutes: 30

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -23,6 +23,8 @@ on:
       - e2e*
   workflow_dispatch:
     # trigger through UI or API
+env:
+  PROJECT_ID: stackdriver-sandbox-e2e
 jobs:
   end-to-end-released:
     runs-on: [self-hosted, e2e-worker]
@@ -53,7 +55,7 @@ jobs:
         set -x
         # run install script
         docker run --rm \
-          -e project_id=$PROJECT_ID \
+          -e project_id=${{ env.PROJECT_ID }} \
           -e skip_workspace_prompt=1 \
           -e release_repo=${{ steps.website_variables.outputs.repo }} \
           -e release_branch=${{ steps.website_variables.outputs.branch }} \
@@ -62,8 +64,6 @@ jobs:
           -v `pwd`:/sandbox-shared \
           --entrypoint /sandbox-shared/.github/workflows/e2e_scripts/run_install.sh \
           ${{ steps.website_variables.outputs.cloudshell_image }}
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Checkout Release Code
       timeout-minutes: 30
       run: |
@@ -78,17 +78,15 @@ jobs:
         # change to previous release code state
         cd ./release-code
         # get cluster zone
-        CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project $PROJECT_ID --format="value(zone)")
+        CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project ${{ env.PROJECT_ID }} --format="value(zone)")
         # build provisioning test image
         docker build -t test-provisioning:$GITHUB_SHA-release tests/provisioning/.
         # run provisioning tests
         docker run --rm \
-          -e GOOGLE_CLOUD_PROJECT=$PROJECT_ID \
+          -e GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }} \
           -e ZONE=$CLUSTER_ZONE \
           -v ~/.config:/root/.config \
           test-provisioning:$GITHUB_SHA-release
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID }}
     - name: Run Monitoring Integration Tests
       timeout-minutes: 30
       run: |
@@ -98,19 +96,17 @@ jobs:
         # install dependencies
         python3 -m pip install -r tests/requirements.txt
         # authenticate cluster
-        CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project $PROJECT_ID --format="value(zone)")
+        CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project ${{ env.PROJECT_ID }} --format="value(zone)")
         gcloud container clusters get-credentials cloud-ops-sandbox --zone "$CLUSTER_ZONE"
         # run tests
-        python3 tests/monitoring_integration_test.py $PROJECT_ID
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
+        python3 tests/monitoring_integration_test.py ${{ env.PROJECT_ID }}
     - name:  Test Using Existing Project
       timeout-minutes: 30
       run: |
         set -x
         # run install script
         docker run --rm \
-          -e project_id=$PROJECT_ID \
+          -e project_id=${{ env.PROJECT_ID }} \
           -e skip_workspace_prompt=1 \
           -e release_repo=${{ steps.website_variables.outputs.repo }} \
           -e release_branch=${{ steps.website_variables.outputs.branch }} \
@@ -119,8 +115,6 @@ jobs:
           -v `pwd`:/sandbox-shared \
           --entrypoint /sandbox-shared/.github/workflows/e2e_scripts/run_install.sh \
           ${{ steps.website_variables.outputs.cloudshell_image }}
-      env:
-        PROJECT_ID: ${{ secrets.E2E_PROJECT_ID  }}
     - name: Clean Project State
       timeout-minutes: 30
       if: ${{ always()  }}

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -18,6 +18,8 @@ on:
     # run on pushes to master
     branches:
       - master
+env:
+  PROJECT_ID: stackdriver-sandbox-230822
 jobs:
   push-master:
     runs-on: [self-hosted, push-privilege]
@@ -29,25 +31,21 @@ jobs:
         set -x
         skaffold config set --global local-cluster false
         # tag with git hash
-        skaffold build --default-repo=gcr.io/$PROJECT_ID \
+        skaffold build --default-repo=gcr.io/${{ env.PROJECT_ID }} \
                        --tag=$GITHUB_SHA
         # tag as latest
-        skaffold build --default-repo=gcr.io/$PROJECT_ID \
+        skaffold build --default-repo=gcr.io/${{ env.PROJECT_ID }} \
                        --tag=latest
-      env:
-        PROJECT_ID: ${{ secrets.PROJECT_ID }}
     - name: Push Load Generator Image to GCR
       timeout-minutes: 20
       run: |
         set -x
         gcloud auth configure-docker --quiet
         # build and tag with git hash
-        IMAGE_SHA=gcr.io/$PROJECT_ID/sandbox/loadgenerator/gke:$GITHUB_SHA
+        IMAGE_SHA=gcr.io/${{ env.PROJECT_ID }}/sandbox/loadgenerator/gke:$GITHUB_SHA
         docker build -t $IMAGE_SHA ./src/loadgenerator
         docker push $IMAGE_SHA
         # build and tag with latest
-        IMAGE_LATEST=gcr.io/$PROJECT_ID/sandbox/loadgenerator/gke:latest
+        IMAGE_LATEST=gcr.io/${{ env.PROJECT_ID }}/sandbox/loadgenerator/gke:latest
         docker build -t $IMAGE_LATEST ./src/loadgenerator
         docker push $IMAGE_LATEST
-      env:
-        PROJECT_ID: ${{ secrets.PROJECT_ID }}

--- a/.github/workflows/push-tags.yml
+++ b/.github/workflows/push-tags.yml
@@ -17,6 +17,8 @@ on:
   push:
     tags:
       - 'v*'
+env:
+  PROJECT_ID: stackdriver-sandbox-230822
 jobs:
   push-tags:
     runs-on: [self-hosted, push-privilege]
@@ -31,20 +33,16 @@ jobs:
         set -x
         skaffold config set --global local-cluster false
         # tag with release version
-        skaffold build --default-repo=gcr.io/$PROJECT_ID \
+        skaffold build --default-repo=gcr.io/${{ env.PROJECT_ID }} \
                        --tag=${{ steps.get_version.outputs.VERSION  }}
-      env:
-        PROJECT_ID: ${{ secrets.PROJECT_ID }}
     - name: Push Load Generator Image to GCR
       timeout-minutes: 20
       run: |
         set -x
         gcloud auth configure-docker --quiet
-        IMAGE=gcr.io/$PROJECT_ID/sandbox/loadgenerator/gke:${{ steps.get_version.outputs.VERSION }}
+        IMAGE=gcr.io/${{ env.PROJECT_ID }}/sandbox/loadgenerator/gke:${{ steps.get_version.outputs.VERSION }}
         docker build -t $IMAGE ./src/loadgenerator
         docker push $IMAGE
-      env:
-        PROJECT_ID: ${{ secrets.PROJECT_ID }}
     - name: Deploy Website to App Engine
       timeout-minutes: 20
       run: |


### PR DESCRIPTION
This lets us automatically run e2e workflows on PRs from RenovateBot

Btw: I looked into setting envvars globally (once across github actions) but it isn't easily done, like it is with setting envvars within workflow, job, or a step. It would require us to write the envvar to Github Actions' runtime disk using one of the workflows. Which feels messy/hard to read for contributors, so I opted to set envvars per each workflow. 

Let me know any feedback!