### PR TITLE
chore: Ignore invalid package versions RenovateBot tries to update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,9 @@
   "labels": [
     "dependencies",
     "type: cleanup",
-    "priority: p2",
-    "automerge"
+    "priority: p2"
+  ],
+  "ignoreDeps": [
+    "com.google.protobuf:protoc"
   ]
 }


### PR DESCRIPTION
- Suppresses wrongful PRs like #523. There is no protobuf:protoc v3.13.0. Latest version is 0.8
- removes "automerge" label from renovatebot, since we require 1 approving review for all PRs. Doing this because automerge label is verbose in the comments