### PR TITLE
fix: e2e release tests

### DIFF
--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -46,6 +46,7 @@ jobs:
         BRANCH=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_git_branch\=).*?(?=&)')
         echo ::set-output name=branch::${BRANCH}
         WORKING_DIR=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_working_dir\=).*?(?=&)')
+        WORKING_DIR="${WORKING_DIR:=./}" # set default value
         echo ::set-output name=dir::${WORKING_DIR}
         CLOUDSHELL_IMAGE=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_image\=).*?(?=")')
         echo ::set-output name=cloudshell_image::${CLOUDSHELL_IMAGE}

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -45,9 +45,6 @@ jobs:
         echo ::set-output name=repo::${REPO}
         BRANCH=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_git_branch\=).*?(?=&)')
         echo ::set-output name=branch::${BRANCH}
-        WORKING_DIR=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_working_dir\=).*?(?=&)')
-        WORKING_DIR="${WORKING_DIR:=./}" # set default value
-        echo ::set-output name=dir::${WORKING_DIR}
         CLOUDSHELL_IMAGE=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_image\=).*?(?=")')
         echo ::set-output name=cloudshell_image::${CLOUDSHELL_IMAGE}
     - name: Run Install Script

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -57,7 +57,6 @@ jobs:
           -e skip_workspace_prompt=1 \
           -e release_repo=${{ steps.website_variables.outputs.repo }} \
           -e release_branch=${{ steps.website_variables.outputs.branch }} \
-          -e release_dir=${{ steps.website_variables.outputs.dir }} \
           -v ~/.config:/root/.config \
           -v `pwd`:/sandbox-shared \
           --entrypoint /sandbox-shared/.github/workflows/e2e_scripts/run_install.sh \

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -51,6 +51,7 @@ jobs:
       timeout-minutes: 30
       run: |
         set -x
+        docker pull ${{ steps.website_variables.outputs.cloudshell_image }}
         # run install script
         docker run --rm \
           -e project_id=${{ env.PROJECT_ID }} \


### PR DESCRIPTION
The end-to-end tests targeting the latest release are failing. The issue is on the latest v0.4.0 release, we removed the `cloudshell_working_dir`argument, which is expected in the test scripts. This PR removes that variable so the tests will run again