### PR TITLE
fix: e2e release tests

### DIFF
--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -45,7 +45,7 @@ jobs:
         echo ::set-output name=repo::${REPO}
         BRANCH=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_git_branch\=).*?(?=&)')
         echo ::set-output name=branch::${BRANCH}
-        CLOUDSHELL_IMAGE=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_image\=).*?(?=")')
+        CLOUDSHELL_IMAGE=$(echo $BTN_CONTENT | grep -o -P '(?<=cloudshell_image\=).*?(?=&)')
         echo ::set-output name=cloudshell_image::${CLOUDSHELL_IMAGE}
     - name: Run Install Script
       timeout-minutes: 30

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -16,7 +16,7 @@ name: "End to End - Release"
 on:
   schedule:
     # run every day at 8pm
-    - cron:  '* 20 * * *'
+    - cron:  '0 20 * * *'
   push:
     # run on pushes to test branch
     branches:

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -77,12 +77,14 @@ jobs:
         cd ./release-code
         # get cluster zone
         CLUSTER_ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project ${{ env.PROJECT_ID }} --format="value(zone)")
+        LOADGEN_ZONE=$(gcloud container clusters list --filter="name:loadgenerator" --project ${{ env.PROJECT_ID }} --format="value(zone)")
         # build provisioning test image
         docker build -t test-provisioning:$GITHUB_SHA-release tests/provisioning/.
         # run provisioning tests
         docker run --rm \
           -e GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }} \
           -e ZONE=$CLUSTER_ZONE \
+          -e LOADGEN_ZONE=$LOADGEN_ZONE \
           -v ~/.config:/root/.config \
           test-provisioning:$GITHUB_SHA-release
     - name: Run Monitoring Integration Tests


### PR DESCRIPTION
- currently, E2E tests against the latest release are failing. It looks like it's incorrectly parsing the clodushell image name. This PR fixes that issue
- the scheduled cronjob seems to be spawning many jobs each day. According to [crontab.guru](https://crontab.guru/#*_20_*_*_*), our old config was asking for "every minute during the hour of 8", so that could be the reason. Changed to "once every day at exactly 8", we'll see if this fixes it