### PR TITLE
Instructions in tutorial and guide for re-launching custom Cloud Shell

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -76,9 +76,11 @@ The URLs in this message tell you where to find the results of the installation:
 
 ### Recovering from session timeout
 Should your Cloud Shell session timeout due to user inactivity, you will need to launch the custom Cloud Shell image to access the `sandboxctl` command.
-Click the button below to restart the custom Cloud Shell.
+Click the
 
-[![Restart your Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.4.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.4.0&cloudshell_tutorial=docs/tutorial.md)
+![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)
+
+button from the [Cloud Operations Sandbox homepage](https://cloud-ops-sandbox.dev/) to restart the custom Cloud Shell
 
 ## Explore your project in GCP
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,12 @@ The URLs in this message tell you where to find the results of the installation:
 
 -  The **load generator** URL takes you to an interface for generating synthetic traffic to Hipster Shop.
 
+### Recovering from session timeout
+Should your Cloud Shell session timeout due to user inactivity, you will need to launch the custom Cloud Shell image to access the `sandboxctl` command.
+Click the button below to restart the custom Cloud Shell.
+
+[![Restart your Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.4.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.4.0&cloudshell_tutorial=docs/tutorial.md)
+
 ## Explore your project in GCP
 
 In another browser tab, navigate to the GCP GKE Dashboard URL, which takes you to the Kubernetes Engine ([documentation](https://cloud.google.com/kubernetes-engine/docs/)) **Workloads** page for the project created by the installer:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -43,6 +43,12 @@ The URLs in this message tell you where to find the results of the installation.
 
 If a message does **not** appear, and the installation script is not able to run, then try running `sandboxctl create` in your Cloud Shell terminal once you have set-up your billing account.
 
+### Recovering from session timeout
+Should your Cloud Shell session timeout due to user inactivity, you will need to launch the custom Cloud Shell image to access the `sandboxctl` command.
+Click the button below to restart the custom Cloud Shell.
+
+[![Restart your Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.4.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.4.0&cloudshell_tutorial=docs/tutorial.md)
+
 ## Explore the Sandbox!
 
 In this tutorial, walk through a guided tour of products in Cloud Operations and explore how they can be used to work with an application.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -45,9 +45,11 @@ If a message does **not** appear, and the installation script is not able to run
 
 ### Recovering from session timeout
 Should your Cloud Shell session timeout due to user inactivity, you will need to launch the custom Cloud Shell image to access the `sandboxctl` command.
-Click the button below to restart the custom Cloud Shell.
+Click the
 
-[![Restart your Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.4.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.4.0&cloudshell_tutorial=docs/tutorial.md)
+![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)
+
+button from the [Cloud Operations Sandbox homepage](https://cloud-ops-sandbox.dev/) to restart the custom Cloud Shell.
 
 ## Explore the Sandbox!
 


### PR DESCRIPTION
Added a brief description of what can happen and a button to relaunch the custom Cloud Shell container to the tutorial and the guide.