### PR TITLE
fixed parameter name

### DIFF
--- a/terraform/monitoring/istio_service_setup.py
+++ b/terraform/monitoring/istio_service_setup.py
@@ -38,7 +38,7 @@ def findService(client, service_name, project_id, zone, should_timeout):
 	num_tries = 0
 	while not found_service and num_tries <= 50:
 		try:
-			found_service = client.get_service(service)
+			found_service = client.get_service(name=service)
 		except: # possible exceptions include GoogleAPICallError and ValueError
 			if should_timeout:
 				num_tries += 1


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/560

We were seeing an issue where it would hang on istio_service_setup, even though all the services were properly set up.

It looks like the issue was due to it interpreting the parameter to `get_service` as a GetServiceRequest object instead of a name string. This PR makes the parameter explicit to fix the issue