### PR TITLE
Warn clicking will terminate Cloud Shell sessions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -76,9 +76,11 @@ The URLs in this message tell you where to find the results of the installation:
 
 ### Recovering from session timeout
 Should your Cloud Shell session timeout due to user inactivity, you will need to launch the custom Cloud Shell image to access the `sandboxctl` command.
-Click the button below to restart the custom Cloud Shell.
+Click the
 
-[![Restart your Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.4.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.4.0&cloudshell_tutorial=docs/tutorial.md)
+![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)
+
+button from the [Cloud Operations Sandbox homepage](https://cloud-ops-sandbox.dev/) to restart the custom Cloud Shell
 
 ## Explore your project in GCP
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,12 @@ The URLs in this message tell you where to find the results of the installation:
 
 -  The **load generator** URL takes you to an interface for generating synthetic traffic to Hipster Shop.
 
+### Recovering from session timeout
+Should your Cloud Shell session timeout due to user inactivity, you will need to launch the custom Cloud Shell image to access the `sandboxctl` command.
+Click the button below to restart the custom Cloud Shell.
+
+[![Restart your Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.4.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.4.0&cloudshell_tutorial=docs/tutorial.md)
+
 ## Explore your project in GCP
 
 In another browser tab, navigate to the GCP GKE Dashboard URL, which takes you to the Kubernetes Engine ([documentation](https://cloud.google.com/kubernetes-engine/docs/)) **Workloads** page for the project created by the installer:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -43,6 +43,12 @@ The URLs in this message tell you where to find the results of the installation.
 
 If a message does **not** appear, and the installation script is not able to run, then try running `sandboxctl create` in your Cloud Shell terminal once you have set-up your billing account.
 
+### Recovering from session timeout
+Should your Cloud Shell session timeout due to user inactivity, you will need to launch the custom Cloud Shell image to access the `sandboxctl` command.
+Click the button below to restart the custom Cloud Shell.
+
+[![Restart your Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.4.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.4.0&cloudshell_tutorial=docs/tutorial.md)
+
 ## Explore the Sandbox!
 
 In this tutorial, walk through a guided tour of products in Cloud Operations and explore how they can be used to work with an application.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -45,9 +45,11 @@ If a message does **not** appear, and the installation script is not able to run
 
 ### Recovering from session timeout
 Should your Cloud Shell session timeout due to user inactivity, you will need to launch the custom Cloud Shell image to access the `sandboxctl` command.
-Click the button below to restart the custom Cloud Shell.
+Click the
 
-[![Restart your Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.4.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.4.0&cloudshell_tutorial=docs/tutorial.md)
+![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)
+
+button from the [Cloud Operations Sandbox homepage](https://cloud-ops-sandbox.dev/) to restart the custom Cloud Shell.
 
 ## Explore the Sandbox!
 

--- a/website/css/main.css
+++ b/website/css/main.css
@@ -284,6 +284,13 @@ li b {
   font-weight: 700;
 }
 
+.warning {
+  color: var(--grey700);
+  font-size: 14px;
+  line-height: 26px;
+  position: relative;
+}
+
 /* mobile view */
 @media (max-width: 1130px) {
   body {

--- a/website/index.html
+++ b/website/index.html
@@ -61,6 +61,7 @@
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
       </div>
+      <p class="warning"><b>Warning!</b> Clicking the button will restart your running Cloud Shell instance.</p>
     </section>
     <section class="cta">
       <h2>Next steps</h2>


### PR DESCRIPTION
Added a warning to the main web page that clicking the button will terminate Cloud Shell session

fixes #550 