### PR TITLE
Extend rating service API with GET ratings/ call to simplify integration with frontend

### DIFF
--- a/src/ratingservice/README.md
+++ b/src/ratingservice/README.md
@@ -1,8 +1,28 @@
 # Rating Service
 
-Rating Service is a microservice developed in Python3 to run on App Engine Standard Environment. It allows to place a rating for an abstract entity in range from 1 to 5 and to get a rating of an entity. Entities are identified using a non-empty string with up to 16 bytes. In order for the service to run correct rating all the time, placed ratings should be processed by calling a dedicated API.
+Rating Service is a microservice in Python developed to run on App Engine Standard Environment.
+It manages ratings of the Hipster shop products graded in scale from 1 to 5.
+The collection of pairs {entity id, rating} are stored in Postgres database managed by Cloud SQL.
+The service exposes GET APIs to get a collection of all managed ratings or to get a rating of the specific product.
+It is possible to submit a new vote for the product's rating. New vote get recollected on demand and the new product rating is calculated as an average of the current rating and all submitted votes.
+The vote recollection is implemented as a scheduled task (using Cloud Schedule) which is triggered each two minutes.
 
-The service is deployed to GAE Standard Environment and stores rating data in the dedicated Postgres DB that is managed by Cloud SQL.
+## Deployment
 
-In order to be deployed to the named service, Google App Engine requires a "default" service to be defined. A simple pong Web application is provided to be deployed as the default service.
-The pong application returns "pong" string on `GET /` request.
+The service is deployed using Terraform module [ratingservice](../../terraform/ratingservice).
+To deploy the service during development you should generate `app.yaml` file with the following parameters:
+
+```yaml
+```
+
+A template of the file can be found in the [ratingservice](../../terraform/ratingservice) folder.
+
+## Testing
+
+Rating service [e2e test](../../tests/ratingservice) verifies API correctness. To launch it manually, use the following command:
+
+```bash
+python3 main_test.py $SERVICE_URL $PATH_TO_PRODUCTS_JSON
+```
+
+where `SERVICE_URL` is a root URL of the rating service and `PATH_TO_PRODUCTS_YAML` is a local path to `product.json` file location.

--- a/src/ratingservice/main.py
+++ b/src/ratingservice/main.py
@@ -103,7 +103,7 @@ def getRatings():
             })
         else:
             return makeError(500, 'No available ratings')
-    except:
+    except DatabaseError:
         return makeError(500, 'DB error')
     finally:
         db_connection_pool.putconn(conn)
@@ -143,7 +143,7 @@ def getRatingById(eid):
             })
         else:
             return makeError(404, "invalid entity id")
-    except:
+    except DatabaseError:
         return makeError(500, 'DB error')
     finally:
         db_connection_pool.putconn(conn)
@@ -191,7 +191,7 @@ def postRating():
         return makeResult({})
     except IntegrityError:
         return makeError(404, 'invalid entity id')
-    except:
+    except DatabaseError:
         return makeError(500, 'DB error')
     finally:
         db_connection_pool.putconn(conn)
@@ -220,7 +220,7 @@ def aggregateRatings():
             cursor.execute("DELETE FROM votes WHERE in_process=TRUE")
         conn.commit()
         return makeResult({})
-    except:
+    except DatabaseError:
         return makeError(500, 'DB error')
     finally:
         db_connection_pool.putconn(conn)

--- a/src/ratingservice/main.py
+++ b/src/ratingservice/main.py
@@ -68,6 +68,7 @@ def makeError(code, message):
 
 
 def makeResult(data):
+    print("2", data)
     result = jsonify(data)
     result.status_code = 200
     return result
@@ -75,6 +76,43 @@ def makeResult(data):
 #
 # APIs
 #
+
+
+@app.route('/ratings', methods=['GET'])
+def getRatings():
+    '''Gets a list of all ratings.
+
+    Returns:
+        HTTP status 200 and Json payload { ratings: [{'id': (string), 'rating': (number)}] }
+        HTTP status 500 when there is an error querying DB or no data
+    '''
+
+    conn = getConnection()
+    if conn == None:
+        return makeError(500, 'failed to connect to DB')
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT eid, ROUND(rating,4) FROM ratings")
+            result = cursor.fetchall()
+        conn.commit()
+        print("1")
+        if result != None:
+            print("1")
+            ratings = []
+            print("1")
+            for row in result:
+                # cast to float because flas.jsonify doesn't work with decimal
+                ratings.append({"id": row[0].strip(), "rating": float(row[1])})
+            print("1")
+            return makeResult({
+                'ratings': ratings,
+            })
+        else:
+            return makeError(500, 'No available ratings')
+    except:
+        return makeError(500, 'DB error')
+    finally:
+        db_connection_pool.putconn(conn)
 
 
 @app.route('/rating/<eid>', methods=['GET'])

--- a/src/ratingservice/main.py
+++ b/src/ratingservice/main.py
@@ -68,7 +68,6 @@ def makeError(code, message):
 
 
 def makeResult(data):
-    print("2", data)
     result = jsonify(data)
     result.status_code = 200
     return result
@@ -95,15 +94,10 @@ def getRatings():
             cursor.execute("SELECT eid, ROUND(rating,4) FROM ratings")
             result = cursor.fetchall()
         conn.commit()
-        print("1")
-        if result != None:
-            print("1")
-            ratings = []
-            print("1")
-            for row in result:
-                # cast to float because flas.jsonify doesn't work with decimal
-                ratings.append({"id": row[0].strip(), "rating": float(row[1])})
-            print("1")
+        if result is not None:
+            # cast to float because flask.jsonify doesn't work with decimal
+            ratings = [{"id": eid.strip(), "rating": float(rating)}
+                       for (eid, rating) in result]
             return makeResult({
                 'ratings': ratings,
             })

--- a/tests/ratingservice/main_test.py
+++ b/tests/ratingservice/main_test.py
@@ -52,16 +52,16 @@ class TestEndpoints(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         ratings = res.json().get('ratings')
         self.assertTrue(type(ratings) == list)
-        self.assertEqual(len(ratings), len(products))
-        ids = list(map(lambda r: r['id'], ratings))
-        self.assertTrue(all(p in products for p in ids))
+        ids = [r['id'] for r in ratings]
+        self.assertEqual(set(ids), set(products))
 
-    def testGetRatingPerProduct(self):
-        """ test getting ratings for each shop product """
-        for product in products:
-            url = composeUrl("rating", product)
-            res = self.session.get(url, timeout=TIMEOUT)
-            self.assertEqual(res.status_code, 200)
+    def testGetProductRating(self):
+        """ test getting ratings for a shop product """
+        # use products[0] in "get product rating" test
+        test_product_id = products[0]
+        url = composeUrl("rating", test_product_id)
+        res = self.session.get(url, timeout=TIMEOUT)
+        self.assertEqual(res.status_code, 200)
 
     def testGetRatingNotExist(self):
         """ test getting rating for non-exist product """
@@ -71,8 +71,8 @@ class TestEndpoints(unittest.TestCase):
 
     def testPostNewRating(self):
         """ test posting new rating to a product """
-        # use products[0] in "post new vote" test
-        test_product_id = products[0]
+        # use products[1] in "post new vote" test
+        test_product_id = products[1]
         url = composeUrl("rating")
         res = self.session.post(url, timeout=TIMEOUT, json={
             'rating': 5,
@@ -82,8 +82,8 @@ class TestEndpoints(unittest.TestCase):
 
     def testNewRatingCalculation(self):
         """ test rating calculation after recollection """
-        # use products[1] to avoid counting new vote from testRate() test
-        test_product_id = products[1]
+        # use products[2] to avoid counting new vote from testRate() test
+        test_product_id = products[2]
         new_rating_vote = 5
         url_get = composeUrl("rating", test_product_id)
         url_post = composeUrl("rating")


### PR DESCRIPTION
add GET ratings/ method that returns _all_ ratings to call when showing frontend homepage.
add e2e test for the new API.
increase e2e test timeout to 5 seconds per API call.