### PR TITLE
feat: make loadgenerator optional

### DIFF
--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -141,18 +141,20 @@ def loadgen(traffic_pattern):
 def create(project, *args, **kwargs):
     """Create a new sandbox"""
     os.chdir(os.path.abspath(sys.path[0]))
-    base_command = "../terraform/install.sh"
-    full_command = [base_command]
+    command = "../terraform/install.sh"
+    # add optional project argument
     if project:
-        full_command += ['--project', project]
+        command += f' --project {project}'
+    # add flags passed in to function
     for (arg, value) in kwargs.items():
         if value:
-            full_command.append(f'--{arg}')
+            command += f' --{arg.replace("_", "-")}'
+    print(command)
     os.setpgrp()
     complete = False
     try:
         # run install.sh in a background shell
-        process = subprocess.Popen(full_command, bufsize=0, shell=True)
+        process = subprocess.Popen(command, bufsize=0, shell=True)
         process.communicate()
         complete = True
     finally:

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -128,15 +128,31 @@ def loadgen(traffic_pattern):
     Recipe._auth_cluster('APP')
 
 @cli.command()
-def create():
+@click.option('--project','-p', default=None,
+              help='GCP project to deploy Cloud Operations Sandbox to')
+@click.option('--verbose', '-v', default=False, is_flag=True,
+              help='print commands as they run (set -x)')
+@click.option('--skip-workspace-prompt', default=False, is_flag=True,
+              help="Don't pause for Cloud Monitoring workspace set up")
+@click.option('--skip-loadgenerator', default=False,  is_flag=True,
+              help="Don't deploy a loadgenerator instance")
+@click.option('--service-wait', default=False,  is_flag=True,
+              help='Wait indefinitely for services to be detected by Cloud Monitoring')
+def create(project, *args, **kwargs):
     """Create a new sandbox"""
     os.chdir(os.path.abspath(sys.path[0]))
-    create_command = "../terraform/install.sh"
+    base_command = "../terraform/install.sh"
+    full_command = [base_command]
+    if project:
+        full_command += ['--project', project]
+    for (arg, value) in kwargs.items():
+        if value:
+            full_command.append(f'--{arg}')
     os.setpgrp()
     complete = False
     try:
         # run install.sh in a background shell
-        process = subprocess.Popen([create_command], bufsize=0, shell=True)
+        process = subprocess.Popen(full_command, bufsize=0, shell=True)
         process.communicate()
         complete = True
     finally:

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -149,7 +149,6 @@ def create(project, *args, **kwargs):
     for (arg, value) in kwargs.items():
         if value:
             command += f' --{arg.replace("_", "-")}'
-    print(command)
     os.setpgrp()
     complete = False
     try:

--- a/terraform/05_loadgen.tf
+++ b/terraform/05_loadgen.tf
@@ -15,6 +15,8 @@
 module "loadgen" {
   source = "./loadgen"
 
+  count = "${var.skip_loadgen ? 0 : 1}"
+
   external_ip = data.external.terraform_vars.result.external_ip
   project_id = data.google_project.project.project_id
 

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -308,7 +308,7 @@ displaySuccessMessage() {
     if [[ -n "${loadgen_ip}" ]]; then
         loadgen_addr="http://$loadgen_ip"
         sendTelemetry $project_id loadgen-available
-    else
+    elif [[ -z "${skip_loadgen}"  ]]; then
         loadgen_addr="[not found]"
         sendTelemetry $project_id loadgen-unavailable
     fi
@@ -363,6 +363,10 @@ parseArguments() {
       skip_workspace_prompt=1
       shift
       ;;
+    --skip-loadgenerator)
+      skip_loadgen=1
+      shift
+      ;;
     --service-wait)
       service_wait=1
       shift
@@ -413,6 +417,8 @@ authenticateCluster;
 # || true to prevent errors during monitoring setup from stopping the installation script
 installMonitoring || true;
 getExternalIp;
-loadGen;
+if [[ -z "${skip_loadgen}" ]]; then
+  loadGen;
+fi
 displaySuccessMessage;
 

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -203,9 +203,9 @@ applyTerraform() {
 
   log "Apply Terraform automation"
   if [[ -n "$billing_id" ]]; then
-    terraform apply -auto-approve -var="billing_account=${billing_acct}" -var="project_id=${project_id}" -var="bucket_name=${bucket_name}" -var="var.skip_loadgen=${skip_loadgen:-false}"
+    terraform apply -auto-approve -var="billing_account=${billing_acct}" -var="project_id=${project_id}" -var="bucket_name=${bucket_name}" -var="skip_loadgen=${skip_loadgen:-false}"
   else
-    terraform apply -auto-approve -var="project_id=${project_id}" -var="bucket_name=${bucket_name}"  -var="var.skip_loadgen=${skip_loadgen:-false}"
+    terraform apply -auto-approve -var="project_id=${project_id}" -var="bucket_name=${bucket_name}"  -var="skip_loadgen=${skip_loadgen:-false}"
   fi
 }
 

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -308,7 +308,7 @@ displaySuccessMessage() {
     if [[ -n "${loadgen_ip}" ]]; then
         loadgen_addr="http://$loadgen_ip"
         sendTelemetry $project_id loadgen-available
-    elif [[ -z "${skip_loadgen}"  ]]; then
+    else
         loadgen_addr="[not found]"
         sendTelemetry $project_id loadgen-unavailable
     fi
@@ -320,7 +320,9 @@ displaySuccessMessage() {
     log "     Google Cloud Console KBE Dashboard: $gcp_kubernetes_path"
     log "     Google Cloud Console Monitoring Workspace: $gcp_monitoring_path"
     log "     Hipstershop web app address: http://$external_ip"
-    log "     Load generator web interface: $loadgen_addr"
+    if [[ -z "${skip_loadgen}" ]]; then
+      log "     Load generator web interface: $loadgen_addr"
+    fi
     log ""
     log "To remove the Sandbox once finished using it, run"
     log ""

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -382,6 +382,7 @@ parseArguments() {
       log "-p|--project|--project-id     GCP project to deploy Cloud Operations Sandbox to"
       log "-v|--verbose                  print commands as they run (set -x)"
       log "--skip-workspace-prompt       Don't pause for Cloud Monitoring workspace set up"
+      log "--skip-loadgenerator          Don't deploy a loadgenerator instance"
       log "--service-wait                Wait indefinitely for services to be detected by Cloud Monitoring"
       log ""
       exit 0

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -203,9 +203,9 @@ applyTerraform() {
 
   log "Apply Terraform automation"
   if [[ -n "$billing_id" ]]; then
-    terraform apply -auto-approve -var="billing_account=${billing_acct}" -var="project_id=${project_id}" -var="bucket_name=${bucket_name}"
+    terraform apply -auto-approve -var="billing_account=${billing_acct}" -var="project_id=${project_id}" -var="bucket_name=${bucket_name}" -var="var.skip_loadgen=${skip_loadgen:-false}"
   else
-    terraform apply -auto-approve -var="project_id=${project_id}" -var="bucket_name=${bucket_name}"
+    terraform apply -auto-approve -var="project_id=${project_id}" -var="bucket_name=${bucket_name}"  -var="var.skip_loadgen=${skip_loadgen:-false}"
   fi
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -33,6 +33,6 @@ variable "bucket_name" {
 }
 
 variable "skip_loadgen" {
-  type        = false
+  default     = false
   description = "If true, the load generator will not be deployed."
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,3 +31,8 @@ variable "bucket_name" {
   type        = string
   description = "The name of your bucket to store the state file. Case-sensitive."
 }
+
+variable "skip_loadgen" {
+  type        = false
+  description = "If true, the load generator will not be deployed."
+}


### PR DESCRIPTION
This PR adds a `--skip-loadgenerator` flag to deploy without the loadgen cluster. As part of the change, I also enabled `sandboxctl create` to send arguments to `install.sh`, and documented these arguments at `sandboxctl create --help`. (Previously, install.sh accepted some arguments, but you couldn't use them in sandboxctl)

[Open in Cloud Shell](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=optional-loadgen&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.4.0)