### PR TITLE
add rating service monitoring metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         set -x
         skaffold config set --global local-cluster true
         skaffold run -p local --status-check=false
+        # setup dummy RATING_SERVICE_ADDR; without it frontend microservice will not run
         kubectl set env deployment.apps/frontend RATING_SERVICE_ADDR=http://some.host
     - name: Wait For Pods
       timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,9 @@ pkg/
 .skaffold-*.yaml
 .kubernetes-manifests-*/
 release/*
-terraform/.terraform/
-gterraform/terraform.tfstate
-terraform/terraform.tfstate.backup
-terraform/terraform
 terraform/terraform_0.11.11_linux_amd64.zip
-terraform/terraform.tfstate
+terraform/**/terraform.*
+terraform/**/.terraform/*
 terraform/istio/istioctl
 terraform/istio/istio-*/**
 .token

--- a/src/frontend/rest.go
+++ b/src/frontend/rest.go
@@ -63,6 +63,8 @@ func buildURL(host, resource, id string) (string, error) {
 	return uri.String(), nil
 }
 
+// sendRestRequest abstracts sending GET and POST requests with a timeout, parsing response and error handling.
+// It parses the returned Json into response. Any response with code that is not 200 or 4xx results in error.
 func sendRestRequest(ctx context.Context, method, url string, payload io.Reader, response interface{}) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Millisecond*500)
 	defer cancel()
@@ -105,6 +107,8 @@ func sendRestRequest(ctx context.Context, method, url string, payload io.Reader,
 	}
 }
 
+// getAllRatings sends GET /ratings request to rating service.
+// It returns a map of product ids to ratings.
 func (fe *frontendServer) getAllRatings(ctx context.Context) (map[string]float64, error) {
 	result := make(map[string]float64)
 
@@ -125,6 +129,8 @@ func (fe *frontendServer) getAllRatings(ctx context.Context) (map[string]float64
 	return result, nil
 }
 
+// getRating sends GET /rating/<id> request to rating service where <id> is a product id.
+// It returns the rating of the product and the current number of votes.
 func (fe *frontendServer) getRating(ctx context.Context, id string) (float64, int, error) {
 	url, err := buildURL(fe.ratingSvcAddr, "rating", id)
 	if err != nil {
@@ -139,6 +145,8 @@ func (fe *frontendServer) getRating(ctx context.Context, id string) (float64, in
 	return data.Rating, data.Votes, nil
 }
 
+// postNewRating sends POST /rating request to rating service to submit a new rating of the product.
+// It returns no data because the rating is not updated immediately.
 func (fe *frontendServer) postNewRating(ctx context.Context, id string, rating int32) error {
 	url, err := buildURL(fe.ratingSvcAddr, "rating", "")
 	if err != nil {

--- a/terraform/monitoring/02_dashboards.tf
+++ b/terraform/monitoring/02_dashboards.tf
@@ -24,7 +24,7 @@ resource "google_monitoring_dashboard" "userexp_dashboard" {
 # in the dashboard can be found in the JSON specification file.
 resource "google_monitoring_dashboard" "frontend_dashboard" {
   dashboard_json = file("./dashboards/frontend_dashboard.json")
-} 
+}
 
 # Creates a dashboard for the adservice. The details of the charts
 # in the dashboard can be found in the JSON specification file.
@@ -58,6 +58,11 @@ resource "google_monitoring_dashboard" "productcatalogservice_dashboard" {
   dashboard_json = file("./dashboards/productcatalogservice_dashboard.json")
 }
 
+# Creates a dashboard for the ratingservice.
+resource "google_monitoring_dashboard" "ratingservice_dashboard" {
+  dashboard_json = file("./dashboards/ratingservice_dashboard.json")
+}
+
 # Create generic dashboards for three of the microservices. Since all three microservices
 # will share the same charts across their dashboards, we can leverage Terraform template files
 # in order to reproduce identical dashboards for each microservice.
@@ -67,20 +72,20 @@ resource "google_monitoring_dashboard" "productcatalogservice_dashboard" {
 variable "services" {
   type = list(object({
     service_name = string,
-    service_id = string
+    service_id   = string
   }))
   default = [
     {
       service_name = "Payment Service"
-      service_id = "paymentservice"
+      service_id   = "paymentservice"
     },
     {
       service_name = "Email Service"
-      service_id = "emailservice"
+      service_id   = "emailservice"
     },
     {
       service_name = "Shipping Service"
-      service_id = "shippingservice"
+      service_id   = "shippingservice"
     }
   ]
 }
@@ -90,7 +95,7 @@ variable "services" {
 data "template_file" "dash_json" {
   template = file("./dashboards/generic_dashboard.tmpl")
   count    = length(var.services)
-  vars     = {
+  vars = {
     service_name = var.services[count.index].service_name
     service_id   = var.services[count.index].service_id
   }
@@ -99,7 +104,7 @@ data "template_file" "dash_json" {
 # Create GCP Monitoring Dashboards using the rendered template files that were created in the data
 # resource above. This produces one dashboard for each microservice that we defined above.
 resource "google_monitoring_dashboard" "service_dashboards" {
-  count = length(var.services)
+  count          = length(var.services)
   dashboard_json = <<EOF
 ${data.template_file.dash_json[count.index].rendered}
 EOF

--- a/terraform/monitoring/04_slos.tf
+++ b/terraform/monitoring/04_slos.tf
@@ -194,8 +194,8 @@ resource "google_monitoring_slo" "rating_service_availability_slo" {
         "metric.label.\"response_code\"=\"200\""
       ])
 
-      # The total is the number of non-4XX and 429 responses
-      # We eliminate 4XX responses except 429 since they do not accurately represent server-side 
+      # The total is the number of non-4XX and 429 (Too Many Requests) responses
+      # We eliminate 4XX responses except 429 (Too Many Requests) since they do not accurately represent server-side 
       # failures and have the possibility of skewing our SLO measurements
       total_service_filter = join(" AND ", [
         "metric.type=\"appengine.googleapis.com/http/server/response_count\"",

--- a/terraform/monitoring/04_slos.tf
+++ b/terraform/monitoring/04_slos.tf
@@ -17,13 +17,13 @@
 #   90% of all non-4XX requests within the past 30 day windowed period
 #   return with 200 OK status
 resource "google_monitoring_slo" "custom_service_availability_slo" {
-  count = length(var.custom_services)
-  service = google_monitoring_custom_service.custom_service[count.index].service_id
-  slo_id = "availability-slo"
+  count        = length(var.custom_services)
+  service      = google_monitoring_custom_service.custom_service[count.index].service_id
+  slo_id       = "availability-slo"
   display_name = "Availability SLO with request base SLI (good total ratio)"
 
   # The goal sets our objective for successful requests over the 30 day rolling window period
-  goal = var.custom_services[count.index].availability_goal
+  goal                = var.custom_services[count.index].availability_goal
   rolling_period_days = 30
 
   request_based_sli {
@@ -47,9 +47,9 @@ resource "google_monitoring_slo" "custom_service_availability_slo" {
         "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
         "metadata.user_labels.\"app\"=\"${var.custom_services[count.index].service_id}\"",
         join(" OR ", ["metric.label.\"response_code\"<\"400\"",
-          "metric.label.\"response_code\">=\"500\""])
+        "metric.label.\"response_code\">=\"500\""])
       ])
-      
+
     }
   }
 }
@@ -58,12 +58,12 @@ resource "google_monitoring_slo" "custom_service_availability_slo" {
 # Example SLO is defined as following:
 #   90% of requests that return 200 OK responses return in under 500 ms
 resource "google_monitoring_slo" "custom_service_latency_slo" {
-  count = length(var.custom_services)
-  service = google_monitoring_custom_service.custom_service[count.index].service_id
-  slo_id = "latency-slo"
+  count        = length(var.custom_services)
+  service      = google_monitoring_custom_service.custom_service[count.index].service_id
+  slo_id       = "latency-slo"
   display_name = "Latency SLO with request base SLI (distribution cut)"
 
-  goal = var.custom_services[count.index].latency_goal
+  goal                = var.custom_services[count.index].latency_goal
   rolling_period_days = 30
 
   request_based_sli {
@@ -98,12 +98,12 @@ resource "google_monitoring_slo" "istio_service_availability_slo" {
 
   # Uses the Istio service that is automatically detected and created by installing Istio
   # Identify the service using the string: ist:${project_id}-zone-${zone}-cloud-ops-sandbox-default-${service_id}
-  service = "ist:${var.project_id}-zone-${var.zone}-cloud-ops-sandbox-default-${var.istio_services[count.index].service_id}"
-  slo_id = "availability-slo"
+  service      = "ist:${var.project_id}-zone-${var.zone}-cloud-ops-sandbox-default-${var.istio_services[count.index].service_id}"
+  slo_id       = "availability-slo"
   display_name = "Availability SLO with request base SLI (good total ratio)"
 
   # The goal sets our objective for successful requests over the 30 day rolling window period
-  goal = var.istio_services[count.index].availability_goal
+  goal                = var.istio_services[count.index].availability_goal
   rolling_period_days = 30
 
   request_based_sli {
@@ -127,9 +127,9 @@ resource "google_monitoring_slo" "istio_service_availability_slo" {
         "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
         "metadata.user_labels.\"app\"=\"${var.istio_services[count.index].service_id}\"",
         join(" OR ", ["metric.label.\"response_code\"<\"400\"",
-          "metric.label.\"response_code\">=\"500\""])
+        "metric.label.\"response_code\">=\"500\""])
       ])
-      
+
     }
   }
 }
@@ -138,12 +138,12 @@ resource "google_monitoring_slo" "istio_service_availability_slo" {
 # Example SLO is defined as:
 #   99% of requests that return 200 OK responses return in under 500 ms
 resource "google_monitoring_slo" "istio_service_latency_slo" {
-  count = length(var.istio_services)
-  service = "ist:${var.project_id}-zone-${var.zone}-cloud-ops-sandbox-default-${var.istio_services[count.index].service_id}"
-  slo_id = "latency-slo"
+  count        = length(var.istio_services)
+  service      = "ist:${var.project_id}-zone-${var.zone}-cloud-ops-sandbox-default-${var.istio_services[count.index].service_id}"
+  slo_id       = "latency-slo"
   display_name = "Latency SLO with request base SLI (distribution cut)"
 
-  goal = var.istio_services[count.index].latency_goal
+  goal                = var.istio_services[count.index].latency_goal
   rolling_period_days = 30
 
   request_based_sli {
@@ -163,6 +163,81 @@ resource "google_monitoring_slo" "istio_service_latency_slo" {
         # The upper bound for latency is in ms
         max = var.istio_services[count.index].latency_threshold
 
+      }
+    }
+  }
+}
+
+# Rating service availability SLO:
+# 99% of all non-4XX requests within the past 30 day windowed period
+# return with 200 OK status
+resource "google_monitoring_slo" "rating_service_availability_slo" {
+  # Uses ratingservice service that is automatically detected and created when the service is deployed to App Engine
+  # Identify of the service is built after the following template: gae:${project_id}_servicename
+  service      = "gae:${var.project_id}_ratingservice"
+  slo_id       = "availability-slo"
+  display_name = "Availability SLO with request base SLI (good total ratio)"
+
+  # The goal sets our objective for successful requests over the 30 day rolling window period
+  goal                = 0.99
+  rolling_period_days = 30
+
+  request_based_sli {
+    good_total_ratio {
+
+      # The "good" service is the number of 200 OK responses
+      good_service_filter = join(" AND ", [
+        "metric.type=\"appengine.googleapis.com/http/server/response_count\"",
+        "resource.type=\"gae_app\"",
+        "resource.label.\"version_id\"=\"prod\"",
+        "resource.label.\"module_id\"=\"ratingservice\"",
+        "metric.label.\"response_code\"=\"200\""
+      ])
+
+      # The total is the number of non-4XX and 429 responses
+      # We eliminate 4XX responses except 429 since they do not accurately represent server-side 
+      # failures and have the possibility of skewing our SLO measurements
+      total_service_filter = join(" AND ", [
+        "metric.type=\"appengine.googleapis.com/http/server/response_count\"",
+        "resource.type=\"gae_app\"",
+        "resource.label.\"version_id\"=\"prod\"",
+        "resource.label.\"module_id\"=\"ratingservice\"",
+        join(" OR ", ["metric.label.\"response_code\"<\"400\"",
+          "metric.label.\"response_code\"=\"429\"",
+        "metric.label.\"response_code\">=\"500\""])
+      ])
+    }
+  }
+}
+
+# Rating service latency SLO:
+#   99% of requests that return 200 OK responses return in under 175 ms
+resource "google_monitoring_slo" "rating_service_latency_slo" {
+  # Uses ratingservice service that is automatically detected and created when the service is deployed to App Engine
+  # Identify of the service is built after the following template: gae:${project_id}_servicename
+  service      = "gae:${var.project_id}_ratingservice"
+  slo_id       = "latency-slo"
+  display_name = "Latency SLO with request base SLI (distribution cut)"
+
+  goal                = 0.99
+  rolling_period_days = 30
+
+  request_based_sli {
+    distribution_cut {
+
+      # The distribution filter retrieves latencies of requests that returned 200 OK responses
+      distribution_filter = join(" AND ", [
+        "metric.type=\"appengine.googleapis.com/http/server/response_latencies\"",
+        "resource.type=\"gae_app\"",
+        "resource.label.\"version_id\"=\"prod\"",
+        "resource.label.\"module_id\"=\"ratingservice\"",
+        "metric.label.\"response_code\"=\"200\"",
+      ])
+
+      range {
+        # By not setting a min value, it is automatically set to -infinity
+        # The upper bound for latency is in ms
+        max = 175
       }
     }
   }

--- a/terraform/monitoring/dashboards/ratingservice_dashboard.json
+++ b/terraform/monitoring/dashboards/ratingservice_dashboard.json
@@ -1,0 +1,129 @@
+{
+  "displayName": "Rating Service Dashboard",
+  "gridLayout": {
+    "columns": 2,
+    "widgets": [
+      {
+        "title": "Responses Count by Code",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "legendTemplate": "${metric.labels.response_code}",
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "metric.label.\"response_code\""
+                    ],
+                    "perSeriesAligner": "ALIGN_SUM"
+                  },
+                  "filter": "metric.type=\"appengine.googleapis.com/http/server/response_count\" resource.type=\"gae_app\" resource.label.\"version_id\"=\"prod\" resource.label.\"module_id\"=\"ratingservice\""
+                }
+              }
+            }
+          ],
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "HTTP Response Latency",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_PERCENTILE_95"
+                  },
+                  "filter": "metric.type=\"appengine.googleapis.com/http/server/response_latencies\" resource.type=\"gae_app\" resource.label.\"module_id\"=\"ratingservice\" resource.label.\"version_id\"=\"prod\""
+                },
+                "unitOverride": "1"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Instance Count by State",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "legendTemplate": "${metric.labels.state}",
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_MEAN",
+                    "groupByFields": [
+                      "metric.label.\"state\""
+                    ],
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  },
+                  "filter": "metric.type=\"appengine.googleapis.com/system/instance_count\" resource.type=\"gae_app\" resource.label.\"module_id\"=\"ratingservice\" resource.label.\"version_id\"=\"prod\""
+                }
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "HTTP Denied From Over Quota",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"appengine.googleapis.com/http/server/quota_denial_count\" resource.type=\"gae_app\"",
+                  "secondaryAggregation": {
+                    "perSeriesAligner": "ALIGN_MAX"
+                  }
+                }
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/monitoring_integration_test.py
+++ b/tests/monitoring_integration_test.py
@@ -33,6 +33,7 @@ project_name = 'projects/'
 project_id = ''
 zone = '-'
 
+
 def getProjectId():
     """Retrieves the project id from the script arguments.
     Returns:
@@ -46,378 +47,445 @@ def getProjectId():
 
     return project_id
 
+
 def getZone():
-	"""Retrieves the zone of the Kubernetes cluster hosted on GKE.
-	Raises:
-	MissingZoneError -- When no cluster is found.
-	Returns:
-	str -- the zone
-	"""
-	credentials = GoogleCredentials.get_application_default()
+    """Retrieves the zone of the Kubernetes cluster hosted on GKE.
+    Raises:
+    MissingZoneError -- When no cluster is found.
+    Returns:
+    str -- the zone
+    """
+    credentials = GoogleCredentials.get_application_default()
 
-	service = discovery.build('container', 'v1', credentials=credentials)
+    service = discovery.build('container', 'v1', credentials=credentials)
 
-	zone = '-' # query for all zones
+    zone = '-'  # query for all zones
 
-	request = service.projects().zones().clusters().list(projectId=project_id, zone=zone)
-	response = request.execute()
+    request = service.projects().zones().clusters().list(
+        projectId=project_id, zone=zone)
+    response = request.execute()
 
-	# Retrieve the cluster for cloud-ops-sandbox and its zone
-	clusters = response['clusters']
-	for cluster in clusters:
-		if cluster['name'] == 'cloud-ops-sandbox':
-			zone = cluster['zone']
+    # Retrieve the cluster for cloud-ops-sandbox and its zone
+    clusters = response['clusters']
+    for cluster in clusters:
+        if cluster['name'] == 'cloud-ops-sandbox':
+            zone = cluster['zone']
 
-	if zone == '-':
-		raise MissingZoneError('No zone for the cloud-ops-sandbox cluster was detected')
+    if zone == '-':
+        raise MissingZoneError(
+            'No zone for the cloud-ops-sandbox cluster was detected')
 
-	return zone
+    return zone
+
 
 class TestUptimeCheck(unittest.TestCase):
 
-	external_ip = ''
+    external_ip = ''
 
-	@classmethod
-	def setUpClass(cls):
-		""" Retrieve the external IP of the cluster """
-		with open('out.txt','w+') as fout:
-			out=subprocess.run(["kubectl", "-n", "istio-system", "get", "service", "istio-ingressgateway", "-o", "jsonpath='{.status.loadBalancer.ingress[0].ip}'"], stdout=fout)
-			fout.seek(0)
-			cls.external_ip=fout.read().replace('\'', '')
+    @classmethod
+    def setUpClass(cls):
+        """ Retrieve the external IP of the cluster """
+        with open('out.txt', 'w+') as fout:
+            out = subprocess.run(["kubectl", "-n", "istio-system", "get", "service", "istio-ingressgateway",
+                                  "-o", "jsonpath='{.status.loadBalancer.ingress[0].ip}'"], stdout=fout)
+            fout.seek(0)
+            cls.external_ip = fout.read().replace('\'', '')
 
-	def testNumberOfUptimeChecks(self):
-		"""" Test that ensures there is only one uptime check created """
-		client = monitoring_v3.UptimeCheckServiceClient()
-		configs = client.list_uptime_check_configs(project_name)
-		config_list = []
-		for config in configs:
-			config_list.append(config)
+    def testNumberOfUptimeChecks(self):
+        """" Test that ensures there is only one uptime check created """
+        client = monitoring_v3.UptimeCheckServiceClient()
+        configs = client.list_uptime_check_configs(project_name)
+        config_list = []
+        for config in configs:
+            config_list.append(config)
 
-		self.assertEqual(len(config_list), 1)
+        self.assertEqual(len(config_list), 1)
 
-	def testUptimeCheckName(self):
-		""" Verifies the configured IP address of the uptime check matches the external IP
-				address of the cluster """
-		client = monitoring_v3.UptimeCheckServiceClient()
-		configs = client.list_uptime_check_configs(project_name)
-		config_list = []
-		for config in configs:
-			config_list.append(config)
+    def testUptimeCheckName(self):
+        """ Verifies the configured IP address of the uptime check matches the external IP
+                address of the cluster """
+        client = monitoring_v3.UptimeCheckServiceClient()
+        configs = client.list_uptime_check_configs(project_name)
+        config_list = []
+        for config in configs:
+            config_list.append(config)
 
-		config = config_list[0]
-		self.assertEqual(config.monitored_resource.labels["host"], self.external_ip)
+        config = config_list[0]
+        self.assertEqual(
+            config.monitored_resource.labels["host"], self.external_ip)
 
-	def testUptimeCheckAlertingPolicy(self):
-		""" Test that an alerting policy was created. """
-		client = monitoring_v3.AlertPolicyServiceClient()
-		policies = client.list_alert_policies(project_name)
-		found_uptime_alert = False
-		for policy in policies:
-			if policy.display_name == 'HTTP Uptime Check Alerting Policy':
-				found_uptime_alert = True
+    def testUptimeCheckAlertingPolicy(self):
+        """ Test that an alerting policy was created. """
+        client = monitoring_v3.AlertPolicyServiceClient()
+        policies = client.list_alert_policies(project_name)
+        found_uptime_alert = False
+        for policy in policies:
+            if policy.display_name == 'HTTP Uptime Check Alerting Policy':
+                found_uptime_alert = True
 
-		self.assertTrue(found_uptime_alert)
+        self.assertTrue(found_uptime_alert)
 
-	def testUptimeCheckAlertingPolicyNotificationChannel(self):
-		""" Test that our single notification channel was created. """
-		client = monitoring_v3.NotificationChannelServiceClient()
-		channels = client.list_notification_channels(project_name)
-		channel_list = []
-		for channel in channels:
-			channel_list.append(channel)
+    def testUptimeCheckAlertingPolicyNotificationChannel(self):
+        """ Test that our single notification channel was created. """
+        client = monitoring_v3.NotificationChannelServiceClient()
+        channels = client.list_notification_channels(project_name)
+        channel_list = []
+        for channel in channels:
+            channel_list.append(channel)
 
-		self.assertEqual(len(channel_list), 1)
+        self.assertEqual(len(channel_list), 1)
+
 
 class TestMonitoringDashboard(unittest.TestCase):
-	def checkForDashboard(self, dashboard_display_name):
-		client = v1.DashboardsServiceClient()
-		dashboards = client.list_dashboards(project_name)
-		for dashboard in dashboards:
-			if dashboard.display_name == dashboard_display_name:
-				return True
-		return False
+    def checkForDashboard(self, dashboard_display_name):
+        client = v1.DashboardsServiceClient()
+        dashboards = client.list_dashboards(project_name)
+        for dashboard in dashboards:
+            if dashboard.display_name == dashboard_display_name:
+                return True
+        return False
 
-	def testUserExpDashboard(self):
-		""" Test that the User Experience Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('User Experience Dashboard')
-		self.assertTrue(found_dashboard)
+    def testUserExpDashboard(self):
+        """ Test that the User Experience Dashboard gets created. """
+        found_dashboard = self.checkForDashboard('User Experience Dashboard')
+        self.assertTrue(found_dashboard)
 
-	def testAdServiceDashboard(self):
-		"""" Test that the Ad Service Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('Ad Service Dashboard')
-		self.assertTrue(found_dashboard)
+    def testAdServiceDashboard(self):
+        """" Test that the Ad Service Dashboard gets created. """
+        found_dashboard = self.checkForDashboard('Ad Service Dashboard')
+        self.assertTrue(found_dashboard)
 
-	def testRecommendationServiceDashboard(self):
-		"""" Test that the Recommendation Service Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('Recommendation Service Dashboard')
-		self.assertTrue(found_dashboard)
+    def testRecommendationServiceDashboard(self):
+        """" Test that the Recommendation Service Dashboard gets created. """
+        found_dashboard = self.checkForDashboard(
+            'Recommendation Service Dashboard')
+        self.assertTrue(found_dashboard)
 
-	def testAdServiceDashboard(self):
-		"""" Test that the Ad Service Dashboard gets created. """
-		found_dash = self.checkForDashboard('Ad Service Dashboard')
-		self.assertTrue(found_dash)
+    def testAdServiceDashboard(self):
+        """" Test that the Ad Service Dashboard gets created. """
+        found_dash = self.checkForDashboard('Ad Service Dashboard')
+        self.assertTrue(found_dash)
 
-	def testFrontendServiceDashboard(self):
-		""" Test that the Frontend Service Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('Frontend Service Dashboard')
-		self.assertTrue(found_dashboard)
+    def testFrontendServiceDashboard(self):
+        """ Test that the Frontend Service Dashboard gets created. """
+        found_dashboard = self.checkForDashboard('Frontend Service Dashboard')
+        self.assertTrue(found_dashboard)
 
-	def testEmailServiceDashboard(self):
-		""" Test that the Email Service Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('Email Service Dashboard')
-		self.assertTrue(found_dashboard)
+    def testEmailServiceDashboard(self):
+        """ Test that the Email Service Dashboard gets created. """
+        found_dashboard = self.checkForDashboard('Email Service Dashboard')
+        self.assertTrue(found_dashboard)
 
-	def testPaymentServiceDashboard(self):
-		""" Test that the Payment Service Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('Payment Service Dashboard')
-		self.assertTrue(found_dashboard)
+    def testPaymentServiceDashboard(self):
+        """ Test that the Payment Service Dashboard gets created. """
+        found_dashboard = self.checkForDashboard('Payment Service Dashboard')
+        self.assertTrue(found_dashboard)
 
-	def testShippingServiceDashboard(self):
-		""" Test that the Shipping Service Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('Shipping Service Dashboard')
-		self.assertTrue(found_dashboard)
+    def testShippingServiceDashboard(self):
+        """ Test that the Shipping Service Dashboard gets created. """
+        found_dashboard = self.checkForDashboard('Shipping Service Dashboard')
+        self.assertTrue(found_dashboard)
 
-	def testCartServiceDashboard(self):
-		""" Test that the Cart Service Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('Cart Service Dashboard')
-		self.assertTrue(found_dashboard)
+    def testCartServiceDashboard(self):
+        """ Test that the Cart Service Dashboard gets created. """
+        found_dashboard = self.checkForDashboard('Cart Service Dashboard')
+        self.assertTrue(found_dashboard)
 
-	def testCheckoutServiceDashboard(self):
-		""" Test that the Checkout Service Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('Checkout Service Dashboard')
-		self.assertTrue(found_dashboard)
+    def testCheckoutServiceDashboard(self):
+        """ Test that the Checkout Service Dashboard gets created. """
+        found_dashboard = self.checkForDashboard('Checkout Service Dashboard')
+        self.assertTrue(found_dashboard)
 
-	def testCurrencyServiceDashboard(self):
-		""" Test that the Currency Service Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('Currency Service Dashboard')
-		self.assertTrue(found_dashboard)
+    def testCurrencyServiceDashboard(self):
+        """ Test that the Currency Service Dashboard gets created. """
+        found_dashboard = self.checkForDashboard('Currency Service Dashboard')
+        self.assertTrue(found_dashboard)
 
-	def testProductCatalogServiceDashboard(self):
-		""" Test that the Product Catalog Service Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('Product Catalog Service Dashboard')
-		self.assertTrue(found_dashboard)
+    def testProductCatalogServiceDashboard(self):
+        """ Test that the Product Catalog Service Dashboard gets created. """
+        found_dashboard = self.checkForDashboard(
+            'Product Catalog Service Dashboard')
+        self.assertTrue(found_dashboard)
 
-	def testLogBasedMetricDashboard(self):
-		""" Test that the Log Based Metric Dashboard gets created. """
-		found_dashboard = self.checkForDashboard('Log Based Metric Dashboard')
-		self.assertTrue(found_dashboard)
+    def testLogBasedMetricDashboard(self):
+        """ Test that the Log Based Metric Dashboard gets created. """
+        found_dashboard = self.checkForDashboard('Log Based Metric Dashboard')
+        self.assertTrue(found_dashboard)
+
+    def testRatingServiceDashboard(self):
+        """ Test that the Rating Service Dashboard gets created. """
+        found_dashboard = self.checkForDashboard('Rating Service Dashboard')
+        self.assertTrue(found_dashboard)
+
 
 class TestLogBasedMetric(unittest.TestCase):
-	def setUp(self):
-		self.client = logging_v2.MetricsServiceV2Client()
-		self.project_id = getProjectId()
+    def setUp(self):
+        self.client = logging_v2.MetricsServiceV2Client()
+        self.project_id = getProjectId()
 
-	def testCheckoutServiceLogMetric(self):
-		""" Test that the log based metric for the Checkout Service gets created. """
-		metric_name = self.client.metric_path(self.project_id, "checkoutservice_log_metric")
-		response = self.client.get_log_metric(metric_name)
-		self.assertTrue(response)
+    def testCheckoutServiceLogMetric(self):
+        """ Test that the log based metric for the Checkout Service gets created. """
+        metric_name = self.client.metric_path(
+            self.project_id, "checkoutservice_log_metric")
+        response = self.client.get_log_metric(metric_name)
+        self.assertTrue(response)
+
 
 class TestCustomService(unittest.TestCase):
-	def setUp(self):
-		self.client = monitoring_v3.ServiceMonitoringServiceClient()
-		self.project_id = getProjectId()
+    def setUp(self):
+        self.client = monitoring_v3.ServiceMonitoringServiceClient()
+        self.project_id = getProjectId()
 
-	def checkForService(self, service_name):
-		name = self.client.service_path(self.project_id, service_name)
-		return self.client.get_service(name)
+    def checkForService(self, service_name):
+        name = self.client.service_path(self.project_id, service_name)
+        return self.client.get_service(name)
 
-	def testFrontendServiceExists(self):
-		""" Test that the Frontend Custom Service gets created. """
-		response = self.checkForService('frontend-srv')
-		# check that we found an object
-		self.assertTrue(response)
+    def testFrontendServiceExists(self):
+        """ Test that the Frontend Custom Service gets created. """
+        response = self.checkForService('frontend-srv')
+        # check that we found an object
+        self.assertTrue(response)
 
-	def testCheckoutServiceExists(self):
-		""" Test that the Custom Checkout Service gets created. """
-		response = self.checkForService('checkoutservice-srv')
-		self.assertTrue(response)
+    def testCheckoutServiceExists(self):
+        """ Test that the Custom Checkout Service gets created. """
+        response = self.checkForService('checkoutservice-srv')
+        self.assertTrue(response)
 
-	def testPaymentServiceExists(self):
-		""" Test that the Custom Payment Service gets created. """
-		response = self.checkForService('paymentservice-srv')
-		self.assertTrue(response)
+    def testPaymentServiceExists(self):
+        """ Test that the Custom Payment Service gets created. """
+        response = self.checkForService('paymentservice-srv')
+        self.assertTrue(response)
 
-	def testEmailServiceExists(self):
-		""" Test that the Custom Email Service gets created. """
-		response = self.checkForService('emailservice-srv')
-		self.assertTrue(response)
+    def testEmailServiceExists(self):
+        """ Test that the Custom Email Service gets created. """
+        response = self.checkForService('emailservice-srv')
+        self.assertTrue(response)
 
-	def testShippingServiceExists(self):
-		""" Test that the Custom Shipping Service gets created. """
-		response = self.checkForService('shippingservice-srv')
-		self.assertTrue(response)
+    def testShippingServiceExists(self):
+        """ Test that the Custom Shipping Service gets created. """
+        response = self.checkForService('shippingservice-srv')
+        self.assertTrue(response)
+
 
 class TestServiceSlo(unittest.TestCase):
-	def setUp(self):
-		self.client = monitoring_v3.ServiceMonitoringServiceClient()
-		self.project_id = getProjectId()
+    def setUp(self):
+        self.client = monitoring_v3.ServiceMonitoringServiceClient()
+        self.project_id = getProjectId()
 
-	def checkForSlo(self, service, slo):
-		name = self.client.service_level_objective_path(self.project_id, service, slo)
-		return self.client.get_service_level_objective(name)
+    def checkForSlo(self, service, slo):
+        name = self.client.service_level_objective_path(
+            self.project_id, service, slo)
+        return self.client.get_service_level_objective(name)
 
-	def getIstioService(self, service_name):
-		return 'ist:' + project_id + '-zone-' + zone + '-cloud-ops-sandbox-default-' + service_name
+    def getIstioService(self, service_name):
+        return 'ist:' + project_id + '-zone-' + zone + '-cloud-ops-sandbox-default-' + service_name
 
-	def testFrontendServiceSloExists(self):
-		""" Test that for Frontend Service that two SLOs (availability, latency) get created. """
-		found_availability_slo = self.checkForSlo('frontend-srv', 'availability-slo')
-		self.assertTrue(found_availability_slo)
-		found_latency_slo = self.checkForSlo('frontend-srv', 'latency-slo')
-		self.assertTrue(found_latency_slo)
+    def testFrontendServiceSloExists(self):
+        """ Test that for Frontend Service that two SLOs (availability, latency) get created. """
+        found_availability_slo = self.checkForSlo(
+            'frontend-srv', 'availability-slo')
+        self.assertTrue(found_availability_slo)
+        found_latency_slo = self.checkForSlo('frontend-srv', 'latency-slo')
+        self.assertTrue(found_latency_slo)
 
-	def testCheckoutServiceSloExists(self):
-		""" Test that for Checkout Service that two SLOs (availability, latency) get created. """
-		found_availability_slo = self.checkForSlo('checkoutservice-srv', 'availability-slo')
-		self.assertTrue(found_availability_slo)
-		found_latency_slo = self.checkForSlo('checkoutservice-srv', 'latency-slo')
-		self.assertTrue(found_latency_slo)
+    def testCheckoutServiceSloExists(self):
+        """ Test that for Checkout Service that two SLOs (availability, latency) get created. """
+        found_availability_slo = self.checkForSlo(
+            'checkoutservice-srv', 'availability-slo')
+        self.assertTrue(found_availability_slo)
+        found_latency_slo = self.checkForSlo(
+            'checkoutservice-srv', 'latency-slo')
+        self.assertTrue(found_latency_slo)
 
-	def testPaymentServiceSloExists(self):
-		""" Test that for Payment Service that two SLOs (availability, latency) get created. """
-		found_availability_slo = self.checkForSlo('paymentservice-srv', 'availability-slo')
-		self.assertTrue(found_availability_slo)
-		found_latency_slo = self.checkForSlo('paymentservice-srv', 'latency-slo')
-		self.assertTrue(found_latency_slo)
+    def testPaymentServiceSloExists(self):
+        """ Test that for Payment Service that two SLOs (availability, latency) get created. """
+        found_availability_slo = self.checkForSlo(
+            'paymentservice-srv', 'availability-slo')
+        self.assertTrue(found_availability_slo)
+        found_latency_slo = self.checkForSlo(
+            'paymentservice-srv', 'latency-slo')
+        self.assertTrue(found_latency_slo)
 
-	def testEmailServiceSloExists(self):
-		""" Test that for Email Service that two SLOs (availability, latency) get created. """
-		found_availability_slo = self.checkForSlo('emailservice-srv', 'availability-slo')
-		self.assertTrue(found_availability_slo)
-		found_latency_slo = self.checkForSlo('emailservice-srv', 'latency-slo')
-		self.assertTrue(found_latency_slo)
+    def testEmailServiceSloExists(self):
+        """ Test that for Email Service that two SLOs (availability, latency) get created. """
+        found_availability_slo = self.checkForSlo(
+            'emailservice-srv', 'availability-slo')
+        self.assertTrue(found_availability_slo)
+        found_latency_slo = self.checkForSlo('emailservice-srv', 'latency-slo')
+        self.assertTrue(found_latency_slo)
 
-	def testShippingServiceSloExists(self):
-		""" Test that for Shipping Service that two SLOs (availability, latency) get created. """
-		found_availability_slo = self.checkForSlo('shippingservice-srv', 'availability-slo')
-		self.assertTrue(found_availability_slo)
-		found_latency_slo = self.checkForSlo('shippingservice-srv', 'latency-slo')
-		self.assertTrue(found_latency_slo)
+    def testShippingServiceSloExists(self):
+        """ Test that for Shipping Service that two SLOs (availability, latency) get created. """
+        found_availability_slo = self.checkForSlo(
+            'shippingservice-srv', 'availability-slo')
+        self.assertTrue(found_availability_slo)
+        found_latency_slo = self.checkForSlo(
+            'shippingservice-srv', 'latency-slo')
+        self.assertTrue(found_latency_slo)
 
-	def testCartServiceSloExists(self):
-		""" Test that for each service that two SLOs (availability, latency) get created. """
-		cartservice_id = self.getIstioService('cartservice')
-		found_availability_slo = self.checkForSlo(cartservice_id, 'availability-slo')
-		self.assertTrue(found_availability_slo)
-		found_latency_slo = self.checkForSlo(cartservice_id, 'latency-slo')
-		self.assertTrue(found_latency_slo)
+    def testCartServiceSloExists(self):
+        """ Test that for each service that two SLOs (availability, latency) get created. """
+        cartservice_id = self.getIstioService('cartservice')
+        found_availability_slo = self.checkForSlo(
+            cartservice_id, 'availability-slo')
+        self.assertTrue(found_availability_slo)
+        found_latency_slo = self.checkForSlo(cartservice_id, 'latency-slo')
+        self.assertTrue(found_latency_slo)
 
-	def testProductCatalogServiceSloExists(self):
-		""" Test that for each service that two SLOs (availability, latency) get created. """
-		productcatalogservice_id = self.getIstioService('productcatalogservice')
-		found_availability_slo = self.checkForSlo(productcatalogservice_id, 'availability-slo')
-		self.assertTrue(found_availability_slo)
-		found_latency_slo = self.checkForSlo(productcatalogservice_id, 'latency-slo')
-		self.assertTrue(found_latency_slo)
+    def testProductCatalogServiceSloExists(self):
+        """ Test that for each service that two SLOs (availability, latency) get created. """
+        productcatalogservice_id = self.getIstioService(
+            'productcatalogservice')
+        found_availability_slo = self.checkForSlo(
+            productcatalogservice_id, 'availability-slo')
+        self.assertTrue(found_availability_slo)
+        found_latency_slo = self.checkForSlo(
+            productcatalogservice_id, 'latency-slo')
+        self.assertTrue(found_latency_slo)
 
-	def testCurrencyServiceSloExists(self):
-		""" Test that for each service that two SLOs (availability, latency) get created. """
-		currencyservice_id = self.getIstioService('currencyservice')
-		found_availability_slo = self.checkForSlo(currencyservice_id, 'availability-slo')
-		self.assertTrue(found_availability_slo)
-		found_latency_slo = self.checkForSlo(currencyservice_id, 'latency-slo')
-		self.assertTrue(found_latency_slo)
+    def testCurrencyServiceSloExists(self):
+        """ Test that for each service that two SLOs (availability, latency) get created. """
+        currencyservice_id = self.getIstioService('currencyservice')
+        found_availability_slo = self.checkForSlo(
+            currencyservice_id, 'availability-slo')
+        self.assertTrue(found_availability_slo)
+        found_latency_slo = self.checkForSlo(currencyservice_id, 'latency-slo')
+        self.assertTrue(found_latency_slo)
 
-	def testRecommendationServiceSloExists(self):
-		""" Test that for each service that two SLOs (availability, latency) get created. """
-		recommendationservice_id = self.getIstioService('recommendationservice')
-		found_availability_slo = self.checkForSlo(recommendationservice_id, 'availability-slo')
-		self.assertTrue(found_availability_slo)
-		found_latency_slo = self.checkForSlo(recommendationservice_id, 'latency-slo')
-		self.assertTrue(found_latency_slo)
+    def testRecommendationServiceSloExists(self):
+        """ Test that for each service that two SLOs (availability, latency) get created. """
+        recommendationservice_id = self.getIstioService(
+            'recommendationservice')
+        found_availability_slo = self.checkForSlo(
+            recommendationservice_id, 'availability-slo')
+        self.assertTrue(found_availability_slo)
+        found_latency_slo = self.checkForSlo(
+            recommendationservice_id, 'latency-slo')
+        self.assertTrue(found_latency_slo)
 
-	def testAdServiceSloExists(self):
-		""" Test that for each service that two SLOs (availability, latency) get created. """
-		adservice_id = self.getIstioService('adservice')
-		found_availability_slo = self.checkForSlo(adservice_id, 'availability-slo')
-		self.assertTrue(found_availability_slo)
-		found_latency_slo = self.checkForSlo(adservice_id, 'latency-slo')
-		self.assertTrue(found_latency_slo)
+    def testAdServiceSloExists(self):
+        """ Test that for each service that two SLOs (availability, latency) get created. """
+        adservice_id = self.getIstioService('adservice')
+        found_availability_slo = self.checkForSlo(
+            adservice_id, 'availability-slo')
+        self.assertTrue(found_availability_slo)
+        found_latency_slo = self.checkForSlo(adservice_id, 'latency-slo')
+        self.assertTrue(found_latency_slo)
+
+    def testRatingServiceSloExists(self):
+        """ Test the rating service for having two SLOs (availability, latency) get created. """
+        service_id = 'gae:' + project_id + '_ratingservice'
+        found_availability_slo = self.checkForSlo(
+            service_id, 'availability-slo')
+        self.assertTrue(found_availability_slo)
+        found_latency_slo = self.checkForSlo(service_id, 'latency-slo')
+        self.assertTrue(found_latency_slo)
+
 
 class TestSloAlertPolicy(unittest.TestCase):
-	def setUp(self):
-		self.client = monitoring_v3.AlertPolicyServiceClient()
+    def setUp(self):
+        self.client = monitoring_v3.AlertPolicyServiceClient()
 
-	def checkForAlertingPolicy(self, policy_display_name):
-		policies = self.client.list_alert_policies(project_name)
-		for policy in policies:
-			if policy.display_name == policy_display_name:
-				return True
-		return False
+    def checkForAlertingPolicy(self, policy_display_name):
+        policies = self.client.list_alert_policies(project_name)
+        for policy in policies:
+            if policy.display_name == policy_display_name:
+                return True
+        return False
 
-	def testFrontendServiceSloAlertExists(self):
-		""" Test that the Alerting Policies for the Frontend Service SLO get created. """
-		found_availability_alert = self.checkForAlertingPolicy('Frontend Service Availability Alert Policy')
-		self.assertTrue(found_availability_alert)
-		found_latency_alert = self.checkForAlertingPolicy('Frontend Service Latency Alert Policy')
-		self.assertTrue(found_latency_alert)
+    def testFrontendServiceSloAlertExists(self):
+        """ Test that the Alerting Policies for the Frontend Service SLO get created. """
+        found_availability_alert = self.checkForAlertingPolicy(
+            'Frontend Service Availability Alert Policy')
+        self.assertTrue(found_availability_alert)
+        found_latency_alert = self.checkForAlertingPolicy(
+            'Frontend Service Latency Alert Policy')
+        self.assertTrue(found_latency_alert)
 
-	def testCheckoutServiceSloAlertExists(self):
-		""" Test that the Alerting Policies for the Checkout Service SLO get created. """
-		found_availability_alert = self.checkForAlertingPolicy('Checkout Service Availability Alert Policy')
-		self.assertTrue(found_availability_alert)
-		found_latency_alert = self.checkForAlertingPolicy('Checkout Service Latency Alert Policy')
-		self.assertTrue(found_latency_alert)
+    def testCheckoutServiceSloAlertExists(self):
+        """ Test that the Alerting Policies for the Checkout Service SLO get created. """
+        found_availability_alert = self.checkForAlertingPolicy(
+            'Checkout Service Availability Alert Policy')
+        self.assertTrue(found_availability_alert)
+        found_latency_alert = self.checkForAlertingPolicy(
+            'Checkout Service Latency Alert Policy')
+        self.assertTrue(found_latency_alert)
 
-	def testPaymentServiceSloAlertExists(self):
-		""" Test that the Alerting Policies for the Payment Service SLO get created. """
-		found_availability_alert = self.checkForAlertingPolicy('Payment Service Availability Alert Policy')
-		self.assertTrue(found_availability_alert)
-		found_latency_alert = self.checkForAlertingPolicy('Payment Service Latency Alert Policy')
-		self.assertTrue(found_latency_alert)
+    def testPaymentServiceSloAlertExists(self):
+        """ Test that the Alerting Policies for the Payment Service SLO get created. """
+        found_availability_alert = self.checkForAlertingPolicy(
+            'Payment Service Availability Alert Policy')
+        self.assertTrue(found_availability_alert)
+        found_latency_alert = self.checkForAlertingPolicy(
+            'Payment Service Latency Alert Policy')
+        self.assertTrue(found_latency_alert)
 
-	def testEmailServiceSloAlertExists(self):
-		""" Test that the Alerting Policies for the Email Service SLO get created. """
-		found_availability_alert = self.checkForAlertingPolicy('Email Service Availability Alert Policy')
-		self.assertTrue(found_availability_alert)
-		found_latency_alert = self.checkForAlertingPolicy('Email Service Latency Alert Policy')
-		self.assertTrue(found_latency_alert)
+    def testEmailServiceSloAlertExists(self):
+        """ Test that the Alerting Policies for the Email Service SLO get created. """
+        found_availability_alert = self.checkForAlertingPolicy(
+            'Email Service Availability Alert Policy')
+        self.assertTrue(found_availability_alert)
+        found_latency_alert = self.checkForAlertingPolicy(
+            'Email Service Latency Alert Policy')
+        self.assertTrue(found_latency_alert)
 
-	def testShippingServiceSloAlertExists(self):
-		""" Test that the Alerting Policies for the Shipping Service SLO get created. """
-		found_availability_alert = self.checkForAlertingPolicy('Shipping Service Availability Alert Policy')
-		self.assertTrue(found_availability_alert)
-		found_latency_alert = self.checkForAlertingPolicy('Shipping Service Latency Alert Policy')
-		self.assertTrue(found_latency_alert)
+    def testShippingServiceSloAlertExists(self):
+        """ Test that the Alerting Policies for the Shipping Service SLO get created. """
+        found_availability_alert = self.checkForAlertingPolicy(
+            'Shipping Service Availability Alert Policy')
+        self.assertTrue(found_availability_alert)
+        found_latency_alert = self.checkForAlertingPolicy(
+            'Shipping Service Latency Alert Policy')
+        self.assertTrue(found_latency_alert)
 
-	def testCartServiceSloAlertExists(self):
-		""" Test that the Alerting Policies for the Cart Service SLO get created. """
-		found_availability_alert = self.checkForAlertingPolicy('Cart Service Availability Alert Policy')
-		self.assertTrue(found_availability_alert)
-		found_latency_alert = self.checkForAlertingPolicy('Cart Service Latency Alert Policy')
-		self.assertTrue(found_latency_alert)
+    def testCartServiceSloAlertExists(self):
+        """ Test that the Alerting Policies for the Cart Service SLO get created. """
+        found_availability_alert = self.checkForAlertingPolicy(
+            'Cart Service Availability Alert Policy')
+        self.assertTrue(found_availability_alert)
+        found_latency_alert = self.checkForAlertingPolicy(
+            'Cart Service Latency Alert Policy')
+        self.assertTrue(found_latency_alert)
 
-	def testProductCatalogServiceSloAlertExists(self):
-		""" Test that the Alerting Policies for the Product Catalog Service SLO get created. """
-		found_availability_alert = self.checkForAlertingPolicy('Product Catalog Service Availability Alert Policy')
-		self.assertTrue(found_availability_alert)
-		found_latency_alert = self.checkForAlertingPolicy('Product Catalog Service Latency Alert Policy')
-		self.assertTrue(found_latency_alert)
+    def testProductCatalogServiceSloAlertExists(self):
+        """ Test that the Alerting Policies for the Product Catalog Service SLO get created. """
+        found_availability_alert = self.checkForAlertingPolicy(
+            'Product Catalog Service Availability Alert Policy')
+        self.assertTrue(found_availability_alert)
+        found_latency_alert = self.checkForAlertingPolicy(
+            'Product Catalog Service Latency Alert Policy')
+        self.assertTrue(found_latency_alert)
 
-	def testCurrencyServiceSloAlertExists(self):
-		""" Test that the Alerting Policies for the Currency Service SLO get created. """
-		found_availability_alert = self.checkForAlertingPolicy('Currency Service Availability Alert Policy')
-		self.assertTrue(found_availability_alert)
-		found_latency_alert = self.checkForAlertingPolicy('Currency Service Latency Alert Policy')
-		self.assertTrue(found_latency_alert)
+    def testCurrencyServiceSloAlertExists(self):
+        """ Test that the Alerting Policies for the Currency Service SLO get created. """
+        found_availability_alert = self.checkForAlertingPolicy(
+            'Currency Service Availability Alert Policy')
+        self.assertTrue(found_availability_alert)
+        found_latency_alert = self.checkForAlertingPolicy(
+            'Currency Service Latency Alert Policy')
+        self.assertTrue(found_latency_alert)
 
-	def testRecommendationServiceSloAlertExists(self):
-		""" Test that the Alerting Policies for the Recommendation Service SLO get created. """
-		found_availability_alert = self.checkForAlertingPolicy('Recommendation Service Availability Alert Policy')
-		self.assertTrue(found_availability_alert)
-		found_latency_alert = self.checkForAlertingPolicy('Recommendation Service Latency Alert Policy')
-		self.assertTrue(found_latency_alert)
+    def testRecommendationServiceSloAlertExists(self):
+        """ Test that the Alerting Policies for the Recommendation Service SLO get created. """
+        found_availability_alert = self.checkForAlertingPolicy(
+            'Recommendation Service Availability Alert Policy')
+        self.assertTrue(found_availability_alert)
+        found_latency_alert = self.checkForAlertingPolicy(
+            'Recommendation Service Latency Alert Policy')
+        self.assertTrue(found_latency_alert)
 
-	def testAdServiceSloAlertExists(self):
-		""" Test that the Alerting Policies for the Frontend Service SLO get created. """
-		found_availability_alert = self.checkForAlertingPolicy('Ad Service Availability Alert Policy')
-		self.assertTrue(found_availability_alert)
-		found_latency_alert = self.checkForAlertingPolicy('Ad Service Latency Alert Policy')
-		self.assertTrue(found_latency_alert)
+    def testAdServiceSloAlertExists(self):
+        """ Test that the Alerting Policies for the Frontend Service SLO get created. """
+        found_availability_alert = self.checkForAlertingPolicy(
+            'Ad Service Availability Alert Policy')
+        self.assertTrue(found_availability_alert)
+        found_latency_alert = self.checkForAlertingPolicy(
+            'Ad Service Latency Alert Policy')
+        self.assertTrue(found_latency_alert)
+
 
 if __name__ == '__main__':
-	project_id = getProjectId()
-	project_name = project_name + project_id
-	zone = getZone()
-	unittest.main(argv=['first-arg-is-ignored'])
+    project_id = getProjectId()
+    project_name = project_name + project_id
+    zone = getZone()
+    unittest.main(argv=['first-arg-is-ignored'])


### PR DESCRIPTION
Add a dashboard for monitoring service with the following metrics:
- responses by HTTP code
- 95th percentile of the response latency
- instance count by state
- throttled responses
Add availability (99% of non-4XX and 429 responses return 200) and latency (99% of 200 responses are returned within 150ms) SLOs for 30 window.
Refactor .gitignore to ignore terraform files under /terraform/monitoring.
Some formatting was committed due to use of VSCode for editing.