### PR TITLE
add default value for emailservice env var

### DIFF
--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -121,7 +121,7 @@ class EmailService(BaseEmailService):
 class DummyEmailService(BaseEmailService):
   def SendOrderConfirmation(self, request, context):
     logger.info('A request to send order confirmation email to {} has been received.'.format(request.email))
-    if os.getenv('ENCODE_EMAIL').lower() == 'true':
+    if os.getenv('ENCODE_EMAIL', 'false').lower() == 'true':
       try:
         encoded_email = self.EncodeEmail(request.email)
         request.email = encoded_email


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/607

The service was trying to run `.lower()` on an unset env var, resulting in spammy logs. I added a default value of false to the field to fix this