### PR TITLE
feat: run loadgen for a few seconds during installation

### DIFF
--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -284,11 +284,10 @@ loadGen() {
   gcloud container clusters get-credentials loadgenerator --zone "$LOADGEN_ZONE"
   kubectx loadgenerator=.
 
-  # Kicks of initial load generation via a POST request to Locust web interface
+  # Kicks off initial load generation via a POST request to Locust web interface
   # This is because Locust currently doesn't support CLI and UI at the same time
   TRIES=0
-#  while [[ $(curl -sL -w "%{http_code}"  "http://$loadgen_ip" -o /dev/null --max-time 1) -ne 200  && \
-  while [[ $(curl -XPOST -d "user_count=100&spawn_rate=10" http://$loadgen_ip/swarm -o /dev/null -w "%{http_code}" --max-time 1) -ne 200  && \
+  while [[ $(curl -XPOST -d "user_count=10&spawn_rate=2" http://$loadgen_ip/swarm -o /dev/null -w "%{http_code}" --max-time 1) -ne 200  && \
       "${TRIES}" -lt 20  ]]; do
     log "waiting for load generator instance..."
     sleep 10
@@ -435,4 +434,3 @@ if [[ -z "${skip_loadgen}" ]]; then
   loadGen;
 fi
 displaySuccessMessage;
-

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -287,7 +287,7 @@ loadGen() {
   # Kicks off initial load generation via a POST request to Locust web interface
   # This is because Locust currently doesn't support CLI and UI at the same time
   TRIES=0
-  while [[ $(curl -XPOST -d "user_count=10&spawn_rate=2" http://$loadgen_ip/swarm -o /dev/null -w "%{http_code}" --max-time 1) -ne 200  && \
+  while [[ $(curl -XPOST -d "user_count=50&spawn_rate=10" http://$loadgen_ip/swarm -o /dev/null -w "%{http_code}" --max-time 1) -ne 200  && \
       "${TRIES}" -lt 20  ]]; do
     log "waiting for load generator instance..."
     sleep 10


### PR DESCRIPTION
fix: #601 
Run load generator for ~10-15s during installation. 
Adds ~5s to previous install time. 

**Load specs:** 
user_count=50
spawn_rate=10
At the end of 5 seconds we delete users that have already been created. 

**Note:** 
There's a race condition where `curl http://loadgen_ip/stop` to stop loadgen returns a successful http response (and UI indicates the swarm has terminated..) 

BUT this only terminates users that have already been spawned, not the users that were originally scheduled to spawn! [Bug filed with Locust here](https://github.com/locustio/locust/issues/1661). 

For us this might be nice as sandbox users will continue to get traces/metrics from any undeleted remaining users from Locust.

**Context:** 
We wanted to provide initial traffic telemetry for users to view && still provide Locust loadgen UI. 
Implemented the workaround suggested by this [Locust issue](https://github.com/locustio/locust/issues/831)

**Testing:** 
In Span Viewer, use filter `/http/user_agent:python-requests`