### PR TITLE
fix: cloud build timeout issue

### DIFF
--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -29,6 +29,7 @@ on:
 jobs:
   build-trigger:
     runs-on: [self-hosted, push-privilege]
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
     - name: Run Cloud Build Trigger

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -18,6 +18,7 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
+  timeout: 30m
   args:
   - '-c'
   - |-

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -18,7 +18,7 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
-  timeout: 30m
+  timeout: 1800s
   args:
   - '-c'
   - |-


### PR DESCRIPTION
Our Cloud Build images are failing to build due to the default 10 minute time out. This bumps the number to 30 mins

I won't merge this until this action completes to be sure it works:
https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/runs/1786250435?check_suite_focus=true