### PR TITLE
fix: add config-level timeout

### DIFF
--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -54,3 +54,4 @@ steps:
     docker push $$CERTIFIED_PATH:latest
     docker push $$CERTIFIED_PATH:$$LATEST_TAG
 logsBucket: 'gs://sandbox-cloud-build-logs'
+timeout: 1800s


### PR DESCRIPTION
We're still seeing issues with the cloud build trigger. It looks like a config-level timeout needed to be added in addition to the step-level one.

This change was able succeed in the automated pipeline: https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/actions/runs/518912854