### PR TITLE
Add SRE recipe for rating service

### DIFF
--- a/src/ratingservice/main.py
+++ b/src/ratingservice/main.py
@@ -76,6 +76,15 @@ def makeResult(data):
 # APIs
 #
 
+@app.route('/_ah/warmup')
+def warmup():
+    '''Handles App Engine warmup logic
+    '''
+    conn = getConnection()
+    if conn is not None:
+        db_connection_pool.putconn(conn)
+    return '', 200, {}
+
 
 @app.route('/ratings', methods=['GET'])
 def getRatings():

--- a/sre-recipes/recipe.py
+++ b/sre-recipes/recipe.py
@@ -61,7 +61,9 @@ class Recipe(abc.ABC):
     @staticmethod
     def _run_command(command):
         """Runs the given command and returns any output and error"""
-        process = subprocess.Popen(command.split(), stdout=subprocess.PIPE)
+        process = subprocess.Popen(
+            command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
         output, error = process.communicate()
         return output, error
 

--- a/sre-recipes/recipes/ratings_freshness_recipe/__init__.py
+++ b/sre-recipes/recipes/ratings_freshness_recipe/__init__.py
@@ -1,0 +1,14 @@
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sre-recipes/recipes/ratings_freshness_recipe/ratings_freshness_recipe.py
+++ b/sre-recipes/recipes/ratings_freshness_recipe/ratings_freshness_recipe.py
@@ -43,7 +43,7 @@ class RatingsFreshnessRecipe(Recipe):
         the rating service
         """
         logging.info("Pausing scheduled job of the rating service")
-        print("Breaking rating operations...")
+        print("Breaking service operations...")
         project_id = Recipe._get_project_id()
         if not project_id:
             print("Failed: cannot find project id.")
@@ -66,7 +66,7 @@ class RatingsFreshnessRecipe(Recipe):
         the rating service
         """
         logging.info("Resuming scheduled job of the rating service")
-        print("Restoring rating operations...")
+        print("Restoring broken operations...")
         project_id = Recipe._get_project_id()
         if not project_id:
             print("Failed: cannot find project id.")

--- a/sre-recipes/recipes/ratings_freshness_recipe/ratings_freshness_recipe.py
+++ b/sre-recipes/recipes/ratings_freshness_recipe/ratings_freshness_recipe.py
@@ -53,7 +53,7 @@ class RatingsFreshnessRecipe(Recipe):
             pid=project_id
         )
         _, err_str = Recipe._run_command(pause_command)
-        if "ERROR:" in err_str:
+        if "ERROR:" in str(err_str, "utf-8"):
             print(err_str)
             logging.error("Failed executing service breaking command:" + err_str)
         else:
@@ -76,7 +76,7 @@ class RatingsFreshnessRecipe(Recipe):
             pid=project_id
         )
         _, err_str = Recipe._run_command(resume_command)
-        if "ERROR:" in err_str:
+        if "ERROR:" in str(err_str, "utf-8"):
             print(err_str)
             logging.error("Failed executing service restoring command:" + err_str)
         else:
@@ -89,11 +89,15 @@ class RatingsFreshnessRecipe(Recipe):
         """
         project_id = Recipe._get_project_id()
         print(
-            "Try to change a rating for a shop's items one or more times.",
-            "Try to check SLO Monitoring and look for SLOs that consume error budget.",
-            "For SLO Monitoring open https://pantheon.corp.google.com/monitoring/services?project={pid}".format(
-                pid=project_id
-            ),
+            "\n".join(
+                (
+                    'Product ratings are managed by the "rating service", hosted on Google AppEngine.',
+                    "The service provides APIs that allow other services to get and update products' ratings.",
+                    "The rating data is kept up-to-date by periodically calling an API endpoint that collects",
+                    "all recently sent new rating scores for each product and calculates the new rating",
+                    "based on the old value and the new scores. Try to check if the rating service operates normally.",
+                )
+            )
         )
 
     def verify_broken_service(self):

--- a/sre-recipes/recipes/ratings_freshness_recipe/ratings_freshness_recipe.py
+++ b/sre-recipes/recipes/ratings_freshness_recipe/ratings_freshness_recipe.py
@@ -1,0 +1,134 @@
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- coding: utf-8 -*-
+"""
+This module contains the implementation of rating_freshness recipe
+"""
+
+import logging
+import subprocess
+from recipe import Recipe
+
+
+class RatingsFreshnessRecipe(Recipe):
+    """
+    This class implements 'rating_freshness' which purposefully
+    stops recollect API calls to rating service.
+    """
+
+    name = "rating_freshness"
+
+    def get_name(self):
+        return self.name
+
+    def is_active(self):
+        return True
+
+    def break_service(self):
+        """
+        Pause Cloud scheduler job to stop calls to recollect API of
+        the rating service
+        """
+        logging.info("Pausing scheduled job of the rating service")
+        print("Breaking rating operations...")
+        project_id = Recipe._get_project_id()
+        if not project_id:
+            print("Failed: cannot find project id.")
+            logging.error("Failed pausing scheduled job: no project id.")
+            exit(1)
+        # hide error output to avoid additional hints :)
+        pause_command = "gcloud scheduler jobs pause ratingservice-recollect-job --project {pid} 2> /dev/null".format(
+            pid=project_id
+        )
+        Recipe._run_command(pause_command)
+        print("...done")
+        logging.info("Scheduled job of the rating service paused")
+
+    def restore_service(self):
+        """
+        Resume Cloud scheduler job to restore calls to recollect API of
+        the rating service
+        """
+        logging.info("Resuming scheduled job of the rating service")
+        print("Restoring rating operations...")
+        project_id = Recipe._get_project_id()
+        if not project_id:
+            print("Failed: cannot find project id.")
+            logging.error("Failed pausing scheduled job: no project id.")
+            exit(1)
+        # hide error output to avoid additional hints :)
+        resume_command = "gcloud scheduler jobs resume ratingservice-recollect-job --project {pid} 2> /dev/null".format(
+            pid=project_id
+        )
+        Recipe._run_command(resume_command)
+        print("...done")
+        logging.info("Scheduled job of the rating service resumed")
+
+    def hint(self):
+        """
+        Provides a hint about the root cause of the issue
+        """
+        project_id = Recipe._get_project_id()
+        print(
+            "Try to change a rating for a shop's items one or more times.",
+            "Try to check SLO Monitoring and look for SLOs that consume error budget.",
+            "For SLO Monitoring open https://pantheon.corp.google.com/monitoring/services?project={pid}".format(
+                pid=project_id
+            ),
+        )
+
+    def verify_broken_service(self):
+        """
+        Displays a multiple choice quiz to the user about which service
+        broke and prompts the user for an answer
+        """
+        prompt = "Which service has a breakage?"
+        choices = [
+            "email service",
+            "frontend service",
+            "ad service",
+            "rating service",
+            "recommendation service",
+            "currency service",
+        ]
+        answer = "rating service"
+        Recipe._generate_multiple_choice(prompt, choices, answer)
+
+    def verify_broken_cause(self):
+        """
+        Displays a multiple choice quiz to the user about the cause of
+        the breakage and prompts the user for an answer
+        """
+        prompt = "What is the cause of the break?"
+        choices = [
+            "service does not run",
+            "ratings data inconsistent in the database",
+            "recollect requests fail or missing",
+            "new rating votes requests fail",
+        ]
+        answer = "recollect requests fail or missing"
+        Recipe._generate_multiple_choice(prompt, choices, answer)
+
+    def verify(self):
+        """Verifies the user found the root cause of the broken service"""
+        print(
+            """
+        This is a multiple choice quiz to verify that 
+        you have found the root cause of the break.
+        """
+        )
+        self.verify_broken_service()
+        self.verify_broken_cause()

--- a/sre-recipes/recipes/ratings_freshness_recipe/ratings_freshness_recipe.py
+++ b/sre-recipes/recipes/ratings_freshness_recipe/ratings_freshness_recipe.py
@@ -15,7 +15,7 @@
 
 # -*- coding: utf-8 -*-
 """
-This module contains the implementation of rating_freshness recipe
+This module contains the implementation of rating2 recipe
 """
 
 import logging
@@ -25,11 +25,11 @@ from recipe import Recipe
 
 class RatingsFreshnessRecipe(Recipe):
     """
-    This class implements 'rating_freshness' which purposefully
+    This class implements 'rating2' which purposefully
     stops recollect API calls to rating service.
     """
 
-    name = "recipe_"
+    name = "recipe2"
 
     def get_name(self):
         return self.name

--- a/terraform/monitoring/04_slos.tf
+++ b/terraform/monitoring/04_slos.tf
@@ -258,7 +258,7 @@ resource "google_monitoring_slo" "rating_service_freshness_slo" {
   slo_id       = "freshness-slo"
   display_name = "Rating freshness SLO with window based SLI"
 
-  goal                = 0.999
+  goal                = 0.99
   rolling_period_days = 1
 
   windows_based_sli {

--- a/terraform/monitoring/06_log_based_metric.tf
+++ b/terraform/monitoring/06_log_based_metric.tf
@@ -22,8 +22,8 @@ resource "google_logging_metric" "checkoutservice_logging_metric" {
   name   = "checkoutservice_log_metric"
   filter = "resource.type=k8s_container AND resource.labels.cluster_name=cloud-ops-sandbox AND resource.labels.namespace_name=default AND resource.labels.container_name=server AND orderedItem"
   metric_descriptor {
-    metric_kind = "DELTA"  # set to DELTA for counter-based metric
-    value_type  = "INT64"  # set to INT64 for counter-based metric
+    metric_kind = "DELTA" # set to DELTA for counter-based metric
+    value_type  = "INT64" # set to INT64 for counter-based metric
     unit        = "1"
     labels {
       key         = "product_name"
@@ -87,3 +87,23 @@ resource "google_monitoring_dashboard" "log_based_metric_dashboard" {
 }
 EOF
 }
+
+resource "google_logging_metric" "ratingservice_logging_metric" {
+  name   = "ratingservice_recollect_requests_count"
+  filter = "resource.type=gae_app AND resource.labels.module_id=ratingservice AND resource.labels.version_id=prod protoPayload.method=POST AND protoPayload.resource=\"/ratings:recollect\""
+  metric_descriptor {
+    metric_kind = "DELTA" # set to DELTA for counter-based metric
+    value_type  = "INT64" # set to INT64 for counter-based metric
+    unit        = "1"
+    labels {
+      key         = "status"
+      value_type  = "INT64"
+      description = "Response status"
+    }
+    display_name = "Number of recollect requests to rating service"
+  }
+  label_extractors = {
+    "status" = "EXTRACT(protoPayload.status)"
+  }
+}
+

--- a/terraform/ratingservice/app.yaml.tpl
+++ b/terraform/ratingservice/app.yaml.tpl
@@ -8,6 +8,8 @@ env_variables:
     DB_USERNAME: '${db_username}'
     DB_PASSWORD: '${db_password}'
     MAX_DB_CONNECTIONS: ${max_connections}
-basic_scaling:
-  max_instances: 10
-  idle_timeout: 10m
+inbound_services:
+- warmup
+auto_scaling:
+  min_instances: 1
+  max_concurrent_requests: 9


### PR DESCRIPTION
A new recipe 'rating_freshness' is added that should cover data freshness SLO of the rating service.
To support the recipe a new (3rd) SLO is define for the rating service. This is 1 day rollowing window SLO that defines a good time as a 1 minute interval during which there were at least 1 successful call to recollect API.
The SLO uses log-based metric which counts number of calls to recollect API.