### PR TITLE
[docs] update codelab link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ __Note__: If installation stops due to billing account errors, set up the billin
 
 * Explore your Sandbox deployment and its [architecture](#Service-Overview)
 * Follow the [User Guide](/docs/README.md) to start using Ops Management
-* Learn more about Ops Management using [Code Labs](https://codelabs.developers.google.com/gcp-next/?cat=Monitoring)
+* Learn more about Ops Management using [Code Labs](https://codelabs.developers.google.com/s/results?q=Monitoring)
 
 ### Clean Up
 


### PR DESCRIPTION
Change the link to search for monitoring as current link is broken and there is no monitoring category in the codelabs anymore.

There is cloud event/folder in the codelabs site but it seems not searchable so cannot limit search result to GCP.