### PR TITLE
fix: add gcp debugger to email service

### DIFF
--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -43,13 +43,16 @@ import googlecloudprofiler
 from logger import getJSONLogger
 logger = getJSONLogger('emailservice-server')
 
-# try:
-#     googleclouddebugger.enable(
-#         module='emailserver',
-#         version='1.0.0'
-#     )
-# except:
-#     pass
+try:
+    import googleclouddebugger
+    googleclouddebugger.enable(
+        module='emailserver',
+        version='1.0.0'
+    )
+except ImportError:
+    logger.error("could not enable debugger")
+    logger.error(traceback.print_exc())
+    pass
 
 # Loads confirmation email template from file
 env = Environment(

--- a/src/emailservice/requirements.in
+++ b/src/emailservice/requirements.in
@@ -1,4 +1,5 @@
 google-api-core==1.26.3
+google-python-cloud-debugger==2.15
 grpcio-health-checking==1.30.0
 grpcio==1.36.1
 jinja2==2.11.3

--- a/src/emailservice/requirements.txt
+++ b/src/emailservice/requirements.txt
@@ -8,13 +8,14 @@ cachetools==4.2.2         # via google-auth
 certifi==2020.12.5        # via requests
 chardet==3.0.4            # via requests
 google-api-core[grpc]==1.26.3  # via -r requirements.in, google-api-python-client, google-cloud-core, google-cloud-monitoring, google-cloud-trace
-google-api-python-client==1.12.8  # via google-cloud-profiler
-google-auth-httplib2==0.0.4  # via google-api-python-client, google-cloud-profiler
-google-auth==1.24.0       # via google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-profiler
+google-api-python-client==1.12.8  # via google-cloud-profiler, google-python-cloud-debugger
+google-auth-httplib2==0.0.4  # via google-api-python-client, google-cloud-profiler, google-python-cloud-debugger
+google-auth==1.24.0       # via google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-profiler, google-python-cloud-debugger
 google-cloud-core==1.4.4  # via google-cloud-trace
 google-cloud-monitoring==0.36.0  # via opentelemetry-exporter-google-cloud
 google-cloud-profiler==1.1.2  # via -r requirements.in
 google-cloud-trace==0.24.0  # via -r requirements.in, opentelemetry-exporter-google-cloud
+google-python-cloud-debugger==2.15  # via -r requirements.in
 googleapis-common-protos==1.52.0  # via google-api-core
 grpcio-health-checking==1.30.0  # via -r requirements.in
 grpcio==1.36.1            # via -r requirements.in, google-api-core, grpcio-health-checking, opentelemetry-instrumentation-grpc
@@ -34,9 +35,10 @@ pyasn1==0.4.8             # via pyasn1-modules, rsa
 pyparsing==2.4.7          # via httplib2, packaging
 python-json-logger==0.1.11  # via -r requirements.in
 pytz==2018.9              # via google-api-core
+pyyaml==5.4.1             # via google-python-cloud-debugger
 requests==2.24.0          # via -r requirements.in, google-api-core, google-cloud-profiler
 rsa==4.6                  # via google-auth
-six==1.15.0               # via google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-core, grpcio, protobuf
+six==1.15.0               # via google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-core, google-python-cloud-debugger, grpcio, protobuf
 uritemplate==3.0.1        # via google-api-python-client
 urllib3==1.25.10          # via requests
 wrapt==1.12.1             # via opentelemetry-instrumentation

--- a/src/recommendationservice/recommendation_server.py
+++ b/src/recommendationservice/recommendation_server.py
@@ -43,6 +43,7 @@ try:
     import googleclouddebugger
     googleclouddebugger.enable(
         module='recommendationservice',
+        version='1.0.0'
     )
 except ImportError:
     logger.error("could not enable debugger")

--- a/src/recommendationservice/recommendation_server.py
+++ b/src/recommendationservice/recommendation_server.py
@@ -20,7 +20,6 @@ import time
 import traceback
 from concurrent import futures
 
-import googleclouddebugger
 import grpc
 
 
@@ -39,6 +38,16 @@ from grpc_health.v1 import health_pb2_grpc
 
 from logger import getJSONLogger
 logger = getJSONLogger('recommendationservice-server')
+
+try:
+    import googleclouddebugger
+    googleclouddebugger.enable(
+        module='recommendationservice',
+    )
+except ImportError:
+    logger.error("could not enable debugger")
+    logger.error(traceback.print_exc())
+    pass
 
 
 class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
@@ -82,15 +91,6 @@ if __name__ == "__main__":
     trace.get_tracer_provider().add_span_processor(
         SimpleExportSpanProcessor(cloud_trace_exporter)
     )
-
-    try:
-        googleclouddebugger.enable(
-            module='recommendationservice',
-        )
-    except (Exception, err):
-        logger.error("could not enable debugger")
-        logger.error(traceback.print_exc())
-        pass
 
     port = os.environ.get('PORT', "8080")
     catalog_addr = os.environ.get('PRODUCT_CATALOG_SERVICE_ADDR', '')


### PR DESCRIPTION
Re-enables the GCP debugger for emailservice. It was taken out previously due to the old package breaking

Also modified how the debugger is enabled in the recomendation service so both services are consistent

Fixes https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/325