### PR TITLE
Fix sandboxctl destroy timeout

### DIFF
--- a/sre-recipes/recipe.py
+++ b/sre-recipes/recipe.py
@@ -66,6 +66,16 @@ class Recipe(abc.ABC):
         )
         output, error = process.communicate()
         return output, error
+    
+    @staticmethod
+    def _run_command_interactive(command):
+        """Runs the given interactive command that waits for user input and returns any output and error"""
+        process = subprocess.Popen(
+            command.split(), shell=True, stderr=subprocess.PIPE
+        )
+        output, error = process.communicate()
+        return output, error
+
 
     @staticmethod
     def _get_project_id():

--- a/sre-recipes/recipe.py
+++ b/sre-recipes/recipe.py
@@ -70,11 +70,8 @@ class Recipe(abc.ABC):
     @staticmethod
     def _run_command_interactive(command):
         """Runs the given interactive command that waits for user input and returns any output and error"""
-        process = subprocess.Popen(
-            command.split(), shell=True, stderr=subprocess.PIPE
-        )
-        output, error = process.communicate()
-        return output, error
+        process = subprocess.run(command.split())
+        return 
 
 
     @staticmethod

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -200,7 +200,7 @@ def destroy():
     """Delete an existing sandbox"""
     os.chdir(os.path.abspath(sys.path[0]))
     destroy_command = "../terraform/destroy.sh"
-    Recipe._run_command(destroy_command)
+    Recipe._run_command_interactive(destroy_command)
 
 
 if __name__ == "__main__":

--- a/terraform/destroy.sh
+++ b/terraform/destroy.sh
@@ -20,7 +20,7 @@ set -o errexit  # Exit on error
 #set -x
 
 log() { echo "$1" >&2;  }
-echo 'Start shutting down resources and deleting the project, this should take about 20 mins. Please do not close the session.'
+
 IFS=$'\n'
 acct=$(gcloud info --format="value(config.account)")
 
@@ -83,7 +83,7 @@ gcloud projects delete $PROJECT_ID
 
 
 # if user backed out or deletion failed, stop script
-found=$(gcloud projects list --filter="${PROJECT_ID}" --format="value(projectId)")
+found=$(gcloud projects describe ${PROJECT_ID} --flatten="lifecycleState" |grep "ACTIVE")
 if [[ -n "${found}" ]]; then
     log "project $PROJECT_ID not deleted"
     sendTelemetry $PROJECT_ID sandbox-not-destroyed

--- a/terraform/destroy.sh
+++ b/terraform/destroy.sh
@@ -20,7 +20,7 @@ set -o errexit  # Exit on error
 #set -x
 
 log() { echo "$1" >&2;  }
-
+echo 'Start shutting down resources and deleteing the project, this should take about 20 mins. Please don't close the session.'
 IFS=$'\n'
 acct=$(gcloud info --format="value(config.account)")
 

--- a/terraform/destroy.sh
+++ b/terraform/destroy.sh
@@ -20,7 +20,7 @@ set -o errexit  # Exit on error
 #set -x
 
 log() { echo "$1" >&2;  }
-echo 'Start shutting down resources and deleteing the project, this should take about 20 mins. Please do not close the session.'
+echo 'Start shutting down resources and deleting the project, this should take about 20 mins. Please do not close the session.'
 IFS=$'\n'
 acct=$(gcloud info --format="value(config.account)")
 

--- a/terraform/destroy.sh
+++ b/terraform/destroy.sh
@@ -20,7 +20,7 @@ set -o errexit  # Exit on error
 #set -x
 
 log() { echo "$1" >&2;  }
-echo 'Start shutting down resources and deleteing the project, this should take about 20 mins. Please don't close the session.'
+echo 'Start shutting down resources and deleteing the project, this should take about 20 mins. Please do not close the session.'
 IFS=$'\n'
 acct=$(gcloud info --format="value(config.account)")
 


### PR DESCRIPTION
Added run_command_interactive to solve sandboxctl destroy hang without affecting other call to run_command function.