### PR TITLE
Support streaming outputs for sandboxctl destroy

### DIFF
--- a/sre-recipes/README.md
+++ b/sre-recipes/README.md
@@ -7,23 +7,23 @@ SRE Recipes is a tool to help users familiarize themselves with finding the root
 To view which recipes exist, run the command below in this directory:
 
 ```
-$ ./sandboxctl --help
+$ ./sandboxctl sre-recipes --help
 ```
 To simulate a break in a specific recipe, run:
 ```
-$ ./sandboxctl break <recipe_name>
+$ ./sandboxctl sre-recipes break <recipe_name>
 ```
 To restore the original condition after simulating a break in a specific recipe, run:
 ```
-$ ./sandboxctl restore <recipe_name>
+$ ./sandboxctl sre-recipes restore <recipe_name>
 ```
 To verify the root cause of the breakage in specific recipe, run:
 ```
-$ ./sandboxctl verify <recipe_name>
+$ ./sandboxctl sre-recipes verify <recipe_name>
 ```
 To receive a hint about the root cause of the breakage, run:
 ```
-$ ./sandboxctl hint <recipe_name>
+$ ./sandboxctl sre-recipes hint <recipe_name>
 ```
 ## Contributing
 

--- a/sre-recipes/recipe.py
+++ b/sre-recipes/recipe.py
@@ -59,13 +59,19 @@ class Recipe(abc.ABC):
         """
 
     @staticmethod
-    def _run_command(command):
-        """Runs the given command and returns any output and error"""
-        process = subprocess.Popen(
-            command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        output, error = process.communicate()
-        return output, error
+    def _run_command(command, capture_output=True):
+        """
+        Runs the given command and returns any captured output and error.
+
+        If 'capture_output' is True (default), we will capture all the stdout
+        and stderr stream, and return the values the caller.
+
+        If 'capture_output' is False, stdout and stderr of current process is
+        used -- all outputs will be streamed to the caller. This function
+        will return (None, None) for this case, since no values are captured.
+        """
+        ret = subprocess.run(command.split(), capture_output=capture_output)
+        return ret.stdout, ret.stderr
 
     @staticmethod
     def _get_project_id():

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -200,7 +200,8 @@ def destroy():
     """Delete an existing sandbox"""
     os.chdir(os.path.abspath(sys.path[0]))
     destroy_command = "../terraform/destroy.sh"
-    Recipe._run_command(destroy_command)
+    # We be verbose and stream the outputs of this long running destroy command
+    Recipe._run_command(destroy_command, capture_output=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Problem:** 

`sandboxctl destroy` can take a while to execute, and it uses the subprocess module, which doesn't stream the terraform destroy logs to users, so it looks as if the command is frozen.

**Solution:**

We add a flag/toggle for streaming stdout and stderr in the module that runs the command.

**Misc**:

We also fix some documentation issues, and simplify the subprocess run logic. Specifically, `subprocess.run` is preferred, and `subprocess.Popen` is the underlying module that it calls.