### PR TITLE
Add Redis Trace instrumentation to cartservice

### DIFF
--- a/src/cartservice/Startup.cs
+++ b/src/cartservice/Startup.cs
@@ -67,6 +67,10 @@ namespace cartservice
                     builder.AddAspNetCoreInstrumentation()
                         .AddOtlpExporter(options =>
                             options.Endpoint = new Uri(Configuration["OTEL_COLLECTOR_ADDR"]));
+                    if (cartStore is RedisCartStore redisCartStore)
+                    {
+                        builder.AddRedisInstrumentation(redisCartStore.RedisConnectionMultiplexer);
+                    }
                 }
             );
         }

--- a/src/cartservice/cartservice.csproj
+++ b/src/cartservice/cartservice.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.1.0-beta4" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc5" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.38.0" />
   </ItemGroup>

--- a/src/cartservice/cartstore/RedisCartStore.cs
+++ b/src/cartservice/cartstore/RedisCartStore.cs
@@ -33,6 +33,8 @@ namespace cartservice.cartstore
         private readonly byte[] emptyCartBytes;
         private readonly string connectionString;
 
+        public IConnectionMultiplexer RedisConnectionMultiplexer => redis;
+
         private readonly ConfigurationOptions redisConnectionOptions;
 
         public RedisCartStore(string redisAddress)
@@ -94,7 +96,7 @@ namespace cartservice.cartstore
                 redis.ConnectionRestored += (o, e) => 
                 {
                     isRedisConnectionOpened = true;
-                    Console.WriteLine("Connection to redis was retored successfully"); 
+                    Console.WriteLine("Connection to redis was restored successfully"); 
                 };
                 redis.ConnectionFailed += (o, e) => 
                 {


### PR DESCRIPTION
This automatically adds trace information for the call from the cartservice to Redis and puts it in the context of the existing call from the frontend to the cartservice.

![image](https://user-images.githubusercontent.com/498727/122827260-5bfff200-d2a1-11eb-8cd8-1e73fef2b5df.png)

The service call is essentially just a wrapper around the Redis call, so they are basically the same in this case, but this is still a useful example of using OpenTelemetry to instrument a third-party library for trace.