### PR TITLE
remove sandboxctl "skip-workspace-prompt" argument

### DIFF
--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -71,7 +71,6 @@ jobs:
         # run install script
         docker run --rm \
           -e project_id=${{ env.PROJECT_ID }} \
-          -e skip_workspace_prompt=1 \
           -e service_wait=1 \
           -v ~/.config:/root/.config \
           -v `pwd`:/sandbox-shared \
@@ -121,7 +120,6 @@ jobs:
         # run install script
         docker run --rm \
           -e project_id=${{ env.PROJECT_ID }} \
-          -e skip_workspace_prompt=1 \
           -e service_wait=1 \
           -v ~/.config:/root/.config \
           -v `pwd`:/sandbox-shared \

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -53,13 +53,10 @@ jobs:
         set -x
         docker pull ${{ steps.website_variables.outputs.cloudshell_image }}
         # run install script
-        # ISTIO_VERSION is fix for v0.5.0. Can be removed after next release
         docker run --rm \
           -e project_id=${{ env.PROJECT_ID }} \
-          -e skip_workspace_prompt=1 \
           -e release_repo=${{ steps.website_variables.outputs.repo }} \
           -e release_branch=${{ steps.website_variables.outputs.branch }} \
-          -e ISTIO_VERSION=1.7.1 \
           -v ~/.config:/root/.config \
           -v `pwd`:/sandbox-shared \
           --entrypoint /sandbox-shared/.github/workflows/e2e_scripts/run_install.sh \

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -53,10 +53,12 @@ jobs:
         set -x
         docker pull ${{ steps.website_variables.outputs.cloudshell_image }}
         # run install script
+        # ISTIO_VERSION is fix for v0.5.0. Can be removed after next release
         docker run --rm \
           -e project_id=${{ env.PROJECT_ID }} \
           -e release_repo=${{ steps.website_variables.outputs.repo }} \
           -e release_branch=${{ steps.website_variables.outputs.branch }} \
+          -e ISTIO_VERSION=1.7.1 \
           -v ~/.config:/root/.config \
           -v `pwd`:/sandbox-shared \
           --entrypoint /sandbox-shared/.github/workflows/e2e_scripts/run_install.sh \

--- a/.github/workflows/e2e_scripts/run_install.sh
+++ b/.github/workflows/e2e_scripts/run_install.sh
@@ -37,13 +37,11 @@ fi
 # enable debug mode
 export DEBUG=1
 
-# print environment variables
-echo $skip_workspace_prompt
+# print project environment variable
 echo $project_id
 
 # trigger install script through cloudshell_open function
-# environment variables project_id and skip_workspace_prompt
-# must be set properly to run in headless mode
+# environment variable project_id  must be set properly to run in headless mode
 echo "running install.sh"
 source /google/devshell/bashrc.google.d/cloudshell_open.sh
 cloudshell_open

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -149,8 +149,6 @@ def loadgen(traffic_pattern):
               help='GCP project to deploy Cloud Operations Sandbox to')
 @click.option('--verbose', '-v', default=False, is_flag=True,
               help='print commands as they run (set -x)')
-@click.option('--skip-workspace-prompt', default=False, is_flag=True,
-              help="Don't pause for Cloud Monitoring workspace set up")
 @click.option('--skip-loadgenerator', default=False,  is_flag=True,
               help="Don't deploy a loadgenerator instance")
 @click.option('--service-wait', default=False,  is_flag=True,

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -355,10 +355,6 @@ parseArguments() {
         exit 1
       fi
       ;;
-    --skip-workspace-prompt)
-      skip_workspace_prompt=1
-      shift
-      ;;
     --skip-loadgenerator)
       skip_loadgen=1
       shift
@@ -377,7 +373,6 @@ parseArguments() {
       log "options:"
       log "-p|--project|--project-id     GCP project to deploy Cloud Operations Sandbox to"
       log "-v|--verbose                  print commands as they run (set -x)"
-      log "--skip-workspace-prompt       Don't pause for Cloud Monitoring workspace set up"
       log "--skip-loadgenerator          Don't deploy a loadgenerator instance"
       log "--service-wait                Wait indefinitely for services to be detected by Cloud Monitoring"
       log ""


### PR DESCRIPTION
We previously had the `--skip-workspace-prompt` to allow our automation to work without interaction. Now that the workspace set-up requirement is gone, we can remove the argument