### PR TITLE
Fix loadgen machine type

### DIFF
--- a/terraform/loadgen/00_loadgen.tf
+++ b/terraform/loadgen/00_loadgen.tf
@@ -68,7 +68,7 @@ resource "google_container_cluster" "gke_loadgen" {
   # interesting things.
   node_pool {
     node_config {
-      machine_type = "n1-standard-2"
+      machine_type = "n1-standard-1"
 
       oauth_scopes = [
         "https://www.googleapis.com/auth/cloud-platform"  

--- a/tests/provisioning/loadgen_test.py
+++ b/tests/provisioning/loadgen_test.py
@@ -57,7 +57,7 @@ class TestLoadGenerator(unittest.TestCase):
         client = cluster_manager.ClusterManagerClient()
         cluster_info = client.get_cluster(name=TestLoadGenerator.name)
         machine_type = cluster_info.node_config.machine_type
-        self.assertEqual(machine_type, 'n1-standard-2')
+        self.assertEqual(machine_type, 'n1-standard-1')
 
     def testNumberOfNode(self):
         """Test if the number of nodes in the node pool is as specified"""


### PR DESCRIPTION
This Loadgen machine type was missed in previous merges.
"n1-standard-1" is what was tested and documented as part of cost estimation optimization and documentation.