### PR TITLE
feat: Add Google Feedback to Sandbox main page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,11 @@ Guidelines](https://opensource.google.com/conduct/).
 
 > 💡 Recommended if you're planning to develop the application.  
 > ℹ️  Prerequisite: [Cloud SDK should be installed.](https://cloud.google.com/sdk/docs/quickstart)  
+> ℹ️  Prerequisite: (if using macbook) Run the following:
+
+```bash  
+brew install coreutils
+```
 
 #### ![kubernetes](docs/img/kubernetes.png) Run Kubernetes micro-services with “Docker for Desktop”
 

--- a/website/deploy/index.html
+++ b/website/deploy/index.html
@@ -78,7 +78,7 @@
   </section>
   <footer>
     <p class="fineprint">* Note: This is <b>NOT</b> an official Google product. Customers will be billed for using cloud resources when creating a sandbox cluster. 
-    <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': '0.7.0' });">Submit Feedback</button>
+    <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': 'v0.6.0' });">Submit Feedback</button>
       </p>
   </footer>
 </body>

--- a/website/deploy/index.html
+++ b/website/deploy/index.html
@@ -34,7 +34,7 @@
 
     gtag('config', 'UA-137862890-1');
   </script>
-  
+  <script type="text/javascript" src='https://www.google.com/tools/feedback/api.js'></script>
 </head>
 <body>
   <section class="page">
@@ -76,9 +76,9 @@
       </div>
     </section>
   </section>
-
   <footer>
-    <p class="fineprint">* Note: This is <b>NOT</b> an official Google product. Customers will be billed for using cloud resources when creating a sandbox cluster.
+    <p class="fineprint">* Note: This is <b>NOT</b> an official Google product. Customers will be billed for using cloud resources when creating a sandbox cluster. 
+    <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': '0.7.0' });">Submit Feedback</button>
       </p>
   </footer>
 </body>

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -75,7 +75,7 @@
 
   <footer>
     <p class="fineprint">* Note: This is <b>NOT</b> an official Google product. Customers will be billed for using cloud resources when creating a sandbox cluster.
-      <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': '0.7.0' });">Submit Feedback</button>
+      <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': 'v0.6.0' });">Submit Feedback</button>
     </p>
   </footer>
 </body>

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -32,6 +32,7 @@
     gtag('config', 'UA-137862890-1');
   </script>
   <!-- End of Google Analytics -->
+  <script type="text/javascript" src='https://www.google.com/tools/feedback/api.js'></script>
 </head>
 <body>
   <section class="page">
@@ -55,7 +56,6 @@
       <h2>Get started now</h2>
       <div class="steps">
         <div class="step step-1">
-          <!--label>Step 1</label-->
           <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.6.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.6.0&cloudshell_tutorial=docs/tutorial.md"
              target="_blank">Open in Google Cloud Shell</a>
         </div>
@@ -68,7 +68,6 @@
       <div class="steps">
         <div class="step step-2">
           <label><a class="docs-btn" href="/docs/">User Guide</a></label>
-	  <!--<a class="github-btn" href="https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/blob/master/docs/README.md">View on GitHub</a> -->
 	</div>
       </div>
     </section>
@@ -76,7 +75,8 @@
 
   <footer>
     <p class="fineprint">* Note: This is <b>NOT</b> an official Google product. Customers will be billed for using cloud resources when creating a sandbox cluster.
-      </p>
+      <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': '0.7.0' });">Submit Feedback</button>
+    </p>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
This PR adds integration with Google Feedback (listnr):
On the main page it will feature a button that will trigger taking a screenshot and sending a report with feedback to Google.

Fixes #725 

(I can't upload a picture from my machine but it looks like this:

[ Submit Feedback ]

And the button is placed on the bottom footer of the landing page.
I tried to test it but it looks like we need to allow-list the domain from which the call is made. So in testing nothing happens on the page. When this code is deployed to cloud-ops-sandbox.dev, it should, upon click, open a screenshot dialog, similar to feedback dialog on cloud.google.com pages.