### PR TITLE
chore: rennovate bot fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 
 Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
 
-[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.6.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.6.0&cloudshell_tutorial=docs/tutorial.md)
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.7.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.7.0&cloudshell_tutorial=docs/tutorial.md)
 
 __Note__: If installation stops due to billing account errors, set up the billing account and type: `sandboxctl create`.
 

--- a/cloud-shell/Dockerfile
+++ b/cloud-shell/Dockerfile
@@ -29,7 +29,7 @@ RUN python3 -m pip install click
 RUN python3 -m pip install google-cloud-monitoring
 
 # set env var
-RUN echo "VERSION=v0.6.0" >> /etc/environment
+RUN echo "VERSION=v0.7.0" >> /etc/environment
 
 # Change "Open in Cloudshell" script to run `sandboxctl create` using local file and changing it
 COPY cloudshell_open_cp.sh /google/devshell/bashrc.google.d/cloudshell_open.sh

--- a/make-release.sh
+++ b/make-release.sh
@@ -37,8 +37,10 @@ sed -i -e "s/uncertified:v\([0-9\.]\+\)/uncertified:${NEW_VERSION}/g" ${REPO_ROO
 
 # update website deployment tag
 sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/website/layouts/index.html;
+sed -i -e "s/productVersion': 'v\([0-9\.]\+\)/productVersion': '${NEW_VERSION}/g" ${REPO_ROOT}/website/layouts/index.html;
 sed -i -e "s/uncertified:v\([0-9\.]\+\)/uncertified:${NEW_VERSION}/g" ${REPO_ROOT}/website/layouts/index.html;
 sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/website/deploy/index.html;
+sed -i -e "s/productVersion': 'v\([0-9\.]\+\)/productVersion': '${NEW_VERSION}/g" ${REPO_ROOT}/website/deploy/index.html;
 sed -i -e "s/uncertified:v\([0-9\.]\+\)/uncertified:${NEW_VERSION}/g" ${REPO_ROOT}/website/deploy/index.html;
 
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "schedule": [
     "after 9am and before 3pm every tuesday"
   ],
-  "prConcurrentLimit": 5,
+  "prConcurrentLimit": 3,
   "gitAuthor": null,
   "packageRules": [
     {
@@ -28,5 +28,6 @@
   },
   "ignoreDeps": [
     "com.google.protobuf:protoc"
-  ]
+  ],
+  "semanticCommits" : "enabled"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -29,5 +29,6 @@
   "ignoreDeps": [
     "com.google.protobuf:protoc"
   ],
-  "semanticCommits" : "enabled"
+  "semanticCommits" : "enabled",
+  "baseBranches": ["develop"]
 }

--- a/website/deploy/index.html
+++ b/website/deploy/index.html
@@ -59,7 +59,7 @@
       <div class="steps">
         <div class="step step-1">
           
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.6.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.6.0&cloudshell_tutorial=docs/tutorial.md"
+          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.7.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.7.0&cloudshell_tutorial=docs/tutorial.md"
              target="_blank">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
@@ -78,7 +78,7 @@
   </section>
   <footer>
     <p class="fineprint">* Note: This is <b>NOT</b> an official Google product. Customers will be billed for using cloud resources when creating a sandbox cluster. 
-    <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': 'v0.6.0' });">Submit Feedback</button>
+    <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': 'v0.7.0' });">Submit Feedback</button>
       </p>
   </footer>
 </body>

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -56,7 +56,7 @@
       <h2>Get started now</h2>
       <div class="steps">
         <div class="step step-1">
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.6.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.6.0&cloudshell_tutorial=docs/tutorial.md"
+          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.7.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.7.0&cloudshell_tutorial=docs/tutorial.md"
              target="_blank">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
@@ -75,7 +75,7 @@
 
   <footer>
     <p class="fineprint">* Note: This is <b>NOT</b> an official Google product. Customers will be billed for using cloud resources when creating a sandbox cluster.
-      <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': 'v0.6.0' });">Submit Feedback</button>
+      <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': 'v0.7.0' });">Submit Feedback</button>
     </p>
   </footer>
 </body>


### PR DESCRIPTION
- added conventional commit styling to rennovate bot
- reduced number of PRs to 3
  - 5 seems to overwhelm the e2e tests when they all rebase at once
