### PR TITLE
ci: add new gitflow enforcer actions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -123,3 +123,20 @@ workloads run using [GitHub self-hosted runners](https://help.github.com/en/acti
 
 #### Actions
 - leaves a comment containing an "Open in Cloud Shell" button
+
+### Gitflow-Enforcer.yml
+
+#### Triggers
+- on each new PR to main
+
+#### Actions
+- Only allow "release/" PRs against master
+
+### Check-Tags.yml
+
+#### Triggers
+- on each new PR to main or develop
+
+#### Actions
+- Checks kubernetes manifests to ensure develop is pinned to `latest`, and main is pinned to a version
+- Checks telemetry id to ensure develop is on `test` and main is on `prod`

--- a/.github/workflows/check-tags.yml
+++ b/.github/workflows/check-tags.yml
@@ -1,0 +1,52 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Tag Check"
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+jobs:
+  check-tags:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check Tags
+      run: |
+        set -x
+
+        if [[ ${{ github.base_ref }} == 'main' ]]; then
+            # if merging into main, manifests should be tagged with explict version
+            expected_tag_regex=":v[0-9]\+\.[0-9]\+\.[0-9]\+$"
+            expected_telemetry="prod"
+        else
+            # if merging into develop, manifests should be pinned to latest
+            expected_tag_regex=":latest"
+            expected_telemetry="test"
+        fi
+        # check manifests
+        num_files=$(cat *-manifests/* | grep image | grep stackdriver-sandbox-230822 | wc -l)
+        num_tagged=$(cat *-manifests/* | grep image | grep stackdriver-sandbox-230822 | grep "$expected_tag_regex" | wc -l)
+        if [[ "$num_tagged" -lt 11 ]]; then
+            # sanity check: we expect at least 11 manifests
+            echo "missing manifests"
+            exit 1
+        fi
+        if [[ "$num_tagged" != "$num_files" ]]; then
+          echo "manifests have incorrect tag"
+          exit 1
+        fi
+        # check for telemetry topic
+        cat terraform/telemetry.py| grep "topic_id =" | grep $expected_telemetry

--- a/.github/workflows/gitflow-enforcer.yml
+++ b/.github/workflows/gitflow-enforcer.yml
@@ -1,0 +1,39 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Gitflow Enforcer Bot"
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+jobs:
+  non-release-pr:
+    runs-on: ubuntu-latest
+    if: "!contains(github.head_ref, 'release/')"
+    steps:
+      - name: Post Warning
+        uses: unsplash/comment-on-pr@85a56be792d927ac4bfa2f4326607d38e80e6e60
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: |
+            ⚠️  **Error:** only release PRs should be merged into `main`, feature PRs should use `develop`
+
+            See our [Contributing Guide](https://github.com/${{ github.repository }}/blob/develop/CONTRIBUTING.md#git-workflow) for more information.
+          check_for_duplicate_msg: true
+      - name: Fail Check
+        run: |
+          echo "not a release branch: ${{ github.head_ref }}"
+          exit 1


### PR DESCRIPTION
Added two new GitHub Actions:
- gitflow-enforcer blocks non-release PRs to main, and adds a comment pointing to the contributing guide
- check-tags ensures that develop and main both maintain proper tagging policies (develop should pin to latest, main should pin to a version)

gitflow-enforcer enforcer is expected to fail for this PR, but we **actually do** want to merge this last one directly to main, to make sure it is protected going forward