### PR TITLE
ci: fix cloud build container workflow

### DIFF
--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   build-trigger:
     runs-on: [self-hosted, push-privilege]
-    timeout-minutes: 30
+    timeout-minutes: 100
     steps:
     - uses: actions/checkout@v2
     - name: Run Cloud Build Trigger

--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -33,6 +33,8 @@ jobs:
     timeout-minutes: 100
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: develop
     - name: Run Cloud Build Trigger
       id: cloud_build
       run: |

--- a/cloud-shell/Dockerfile
+++ b/cloud-shell/Dockerfile
@@ -24,9 +24,9 @@ RUN sudo apt-get install unzip && \
 RUN sudo apt-get -y install postgresql-client jq
 
 # install python libraries
-RUN python3 -m pip install google-cloud-pubsub
-RUN python3 -m pip install click
-RUN python3 -m pip install google-cloud-monitoring
+RUN python3 -m pip install google-cloud-pubsub==2.6.0
+RUN python3 -m pip install click==8.0.1
+RUN python3 -m pip install google-cloud-monitoring==2.4.0
 
 # set env var
 RUN echo "VERSION=develop" >> /etc/environment

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -18,7 +18,7 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
-  timeout: 1800s
+  timeout: 3600s
   args:
   - '-c'
   - |-

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
     # build images for each releases, and repo HEAD
     UNCERTIFIED_PATH=gcr.io/$PROJECT_ID/cloudshell-image/uncertified
     # build latest image
-    git checkout fix-cloud-build
+    git checkout develop
     docker build -t $$UNCERTIFIED_PATH:latest ./cloud-shell
     docker push $$UNCERTIFIED_PATH:latest
     # re-build recent tags

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -18,7 +18,7 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
-  timeout: 3600s
+  timeout: 100m
   args:
   - '-c'
   - |-
@@ -56,4 +56,4 @@ steps:
     docker push $$CERTIFIED_PATH:latest
     docker push $$CERTIFIED_PATH:$$LATEST_TAG
 logsBucket: 'gs://sandbox-cloud-build-logs'
-timeout: 3600s
+timeout: 100m

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -18,7 +18,7 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
-  timeout: 100m
+  timeout: 6000s
   args:
   - '-c'
   - |-
@@ -56,4 +56,4 @@ steps:
     docker push $$CERTIFIED_PATH:latest
     docker push $$CERTIFIED_PATH:$$LATEST_TAG
 logsBucket: 'gs://sandbox-cloud-build-logs'
-timeout: 100m
+timeout: 6000s

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -32,8 +32,8 @@ steps:
     git checkout fix-cloud-build
     docker build -t $$UNCERTIFIED_PATH:latest ./cloud-shell
     docker push $$UNCERTIFIED_PATH:latest
-    # build tags
-    for TAG in $(git tag | sort -V); do
+    # re-build recent tags
+    for TAG in $(git tag | sort -V | tail -3); do
         echo "checking out $$TAG"
         git checkout $$TAG
         # if cloud-build directory exists, build new container

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -56,4 +56,4 @@ steps:
     docker push $$CERTIFIED_PATH:latest
     docker push $$CERTIFIED_PATH:$$LATEST_TAG
 logsBucket: 'gs://sandbox-cloud-build-logs'
-timeout: 1800s
+timeout: 3600s

--- a/cloud-shell/cloudbuild.yaml
+++ b/cloud-shell/cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
     # build images for each releases, and repo HEAD
     UNCERTIFIED_PATH=gcr.io/$PROJECT_ID/cloudshell-image/uncertified
     # build latest image
-    git checkout develop
+    git checkout fix-cloud-build
     docker build -t $$UNCERTIFIED_PATH:latest ./cloud-shell
     docker push $$UNCERTIFIED_PATH:latest
     # build tags


### PR DESCRIPTION
The cloud build container workflow is currently broken. This PR:
- increases timeout
- builds only the 3 latest tags (to save compute time)
- pins python dependency versions in the cloud shell container
- always uses the develop branch as the base