### PR TITLE
fix: update outdated loadgen env variable in sandboxctl

### DIFF
--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -134,6 +134,7 @@ def loadgen(traffic_pattern):
         f"LOCUST_TASK={traffic_pattern}"
     delete_pods_command = "kubectl delete pods -l app=loadgenerator"
 
+    Recipe._auth_cluster('LOADGEN')
     print('Redeploying Loadgenerator...')
     Recipe._run_command(set_env_command)
     Recipe._run_command(delete_pods_command)

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -131,7 +131,7 @@ def sre_recipes(action, recipe_name):
 def loadgen(traffic_pattern):
     """Change traffic patterns for the loadgenerator service"""
     set_env_command = "kubectl set env deployment/loadgenerator "\
-        f"LOCUST_TASK={traffic_pattern}_locustfile.py"
+        f"LOCUST_TASK={traffic_pattern}"
     delete_pods_command = "kubectl delete pods -l app=loadgenerator"
 
     print('Redeploying Loadgenerator...')


### PR DESCRIPTION
Fix outdated sandboxctl command for `loadgen`.

This should fix a potential crash loop in loadgen, but the crash loop in frontend server in issue #791 is unrelated to loadgen. 

It seems to related to availabilities itself.

