### PR TITLE
feat: renamed k8s containers to display service names

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -27,8 +27,8 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       containers:
-      - name: server
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/adservice:latest
+      - name: adservice
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/adservice:v0.7.0
         ports:
         - containerPort: 9555
         env:

--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: adservice
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/adservice:v0.7.0
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/adservice:latest
         ports:
         - containerPort: 9555
         env:

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -31,7 +31,7 @@ spec:
           image: busybox
           command: ['bin/sh', '-c', 'until nslookup redis-cart; do echo waiting for redis; sleep 2; done;']
       containers:
-      - name: server
+      - name: cartservice
         image: gcr.io/stackdriver-sandbox-230822/sandbox/cartservice:latest
         ports:
         - containerPort: 7070

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -26,7 +26,7 @@ spec:
         app: checkoutservice
     spec:
       containers:
-        - name: server
+        - name: checkoutservice
           image: gcr.io/stackdriver-sandbox-230822/sandbox/checkoutservice:latest
           ports:
           - containerPort: 5050

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       containers:
-      - name: server
+      - name: currencyservice
         image: gcr.io/stackdriver-sandbox-230822/sandbox/currencyservice:latest
         ports:
         - name: grpc

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       containers:
-      - name: server
+      - name: emailservice
         image: gcr.io/stackdriver-sandbox-230822/sandbox/emailservice:latest
         ports:
         - containerPort: 8080

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -26,7 +26,7 @@ spec:
         app: frontend
     spec:
       containers:
-        - name: server
+        - name: frontend
           image: gcr.io/stackdriver-sandbox-230822/sandbox/frontend:latest
           ports:
           - containerPort: 8080

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       containers:
-      - name: server
+      - name: paymentservice
         image: gcr.io/stackdriver-sandbox-230822/sandbox/paymentservice:latest
         ports:
         - containerPort: 50051

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       containers:
-      - name: server
+      - name: productcatalogservice
         image: gcr.io/stackdriver-sandbox-230822/sandbox/productcatalogservice:latest
         ports:
         - containerPort: 3550

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       containers:
-      - name: server
+      - name: recommendationservice
         image: gcr.io/stackdriver-sandbox-230822/sandbox/recommendationservice:latest
         ports:
         - containerPort: 8080

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -26,7 +26,7 @@ spec:
         app: shippingservice
     spec:
       containers:
-      - name: server
+      - name: shippingservice
         image: gcr.io/stackdriver-sandbox-230822/sandbox/shippingservice:latest
         ports:
         - containerPort: 50051

--- a/tests/recipes/test_recommendation_crash_recipe.sh
+++ b/tests/recipes/test_recommendation_crash_recipe.sh
@@ -37,7 +37,7 @@ echo "- expecting to see 500 error..."
 curl -I --no-fail $HTTP_ADDR/product/OLJCESPC7Z | grep "500 Internal Server Error" 
 
 echo "- checking for expected recomendationservice log..."
-kubectl logs deploy/recommendationservice server | grep "invalid literal for int() with base 10: '5.0'"
+kubectl logs deploy/recommendationservice recommendationservice | grep "invalid literal for int() with base 10: '5.0'"
 
 echo "- restoring sandbox"
 sandboxctl sre-recipes restore recipe3


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/815

The Cloud Logging dashboard adds the container name beside the log for better readability. Except most of our services use the name "server" for the container, which isn't helpful for debugging.

![image](https://user-images.githubusercontent.com/3914119/127385526-0f050545-4831-4820-a03c-d60cab8e3fa3.png)

This PR will give each service a unique name
