### PR TITLE
fix: website update workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -68,14 +68,6 @@ workloads run using [GitHub self-hosted runners](https://help.github.com/en/acti
 - builds and pushes images to official GCR repo tagged with git commit
 - builds and pushes images to official GCR repo tagged as latest
 
-### Update-Website.yaml
-
-#### Triggers
-- release merged and commits pushed to main
-
-#### Actions
-- push new prod version of the website to App Engine
-
 ### Push-Tags.yaml
 
 #### Triggers
@@ -164,11 +156,26 @@ workloads run using [GitHub self-hosted runners](https://help.github.com/en/acti
 - Checks kubernetes manifests to ensure develop is pinned to `latest`, and main is pinned to a version
 - Checks telemetry id to ensure develop is on `test` and main is on `prod`
 
-### Staging-Website.yml
+### Prod-Website.yaml
+
+#### Triggers
+- release merged and commits pushed to main
+
+#### Actions
+- push new prod version of the website to App Engine
+
+### Manual-Website.yml
+
+#### Triggers
+- on manual trigger
+
+#### Actions
+- sets up a pre-prod GAE website deployment in `stackdriver-sandbox-230822`
+
+### Develop-Website.yml
 
 #### Triggers
 - on each new push to develop
-- on manual trigger
 
 #### Actions
 - sets up a pre-prod GAE website deployment in `stackdriver-sandbox-230822`

--- a/.github/workflows/develop-website.yml
+++ b/.github/workflows/develop-website.yml
@@ -12,21 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Update Website"
+name: "Stage Website - Develop"
 on:
   push:
-    # run on pushes to main (after merging release branches)
+    # run on pushes to develop
     branches:
-      - main
+    - develop
 env:
   PROJECT_ID: stackdriver-sandbox-230822
 jobs:
-  update-website:
+  stage-website:
     runs-on: [self-hosted, push-privilege]
     steps:
     - uses: actions/checkout@v2
-    - name: Deploy Website to App Engine
+    - name: Deploy Staged Website to App Engine
       timeout-minutes: 20
       run: |
         set -x
-        gcloud app deploy website/app.yaml
+        cp website/app.yaml website/staging.app.yaml
+        echo "service: develop" >> website/staging.app.yaml
+        gcloud app deploy website/staging.app.yaml

--- a/.github/workflows/manual-website.yml
+++ b/.github/workflows/manual-website.yml
@@ -1,0 +1,41 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Stage Website - Manual"
+on:
+  push:
+    # run on pushes to develop
+    branches:
+    - develop
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'App Engine Service Name'
+        required: true
+        default: 'staging'
+    # trigger through UI or API
+env:
+  PROJECT_ID: stackdriver-sandbox-230822
+jobs:
+  stage-website:
+    runs-on: [self-hosted, push-privilege]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Deploy Staged Website to App Engine
+      timeout-minutes: 20
+      run: |
+        set -x
+        cp website/app.yaml website/staging.app.yaml
+        echo "service: ${{ github.event.inputs.name  }}" >> website/staging.app.yaml
+        gcloud app deploy website/staging.app.yaml

--- a/.github/workflows/prod-website.yml
+++ b/.github/workflows/prod-website.yml
@@ -12,30 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Stage Website"
+name: "Prod Website"
 on:
   push:
-    # run on pushes to develop
+    # run on pushes to main (after merging release branches)
     branches:
-    - develop
-  workflow_dispatch:
-    inputs:
-      name:
-        description: 'App Engine Service Name'
-        required: true
-        default: 'staging'
-    # trigger through UI or API
+      - main
 env:
   PROJECT_ID: stackdriver-sandbox-230822
 jobs:
-  stage-website:
+  update-website:
     runs-on: [self-hosted, push-privilege]
     steps:
     - uses: actions/checkout@v2
-    - name: Deploy Staged Website to App Engine
+    - name: Deploy Website to App Engine
       timeout-minutes: 20
       run: |
         set -x
-        cp website/app.yaml website/staging.app.yaml
-        echo "service: ${{ github.event.inputs.name  }}" >> website/staging.app.yaml
-        gcloud app deploy website/staging.app.yaml
+        gcloud app deploy website/app.yaml


### PR DESCRIPTION
There was a bug in the GitHub Actions workflow that was meant to update the staging website.  It wasn't setting the AppEngine service name, so it would fall back to `default`. 

This PR fixes the bug, and separates the `develop` and `manual staging` Actions to simplify the logic and make it easier to catch similar bugs in the future