### PR TITLE
fix: telemetry on develop branch

### DIFF
--- a/cloud-shell/cloudshell_open_cp.sh
+++ b/cloud-shell/cloudshell_open_cp.sh
@@ -91,5 +91,7 @@ function cloudshell_open {
   # add terraform directory to path
   export PATH="~/cloudshell_open/cloud-ops-sandbox/terraform:$PATH"
   export PATH="~/cloudshell_open/stackdriver-sandbox/terraform:$PATH"
+  # ensure version environment variable is set
+  source /etc/environment
   sandboxctl create # This line automatically runs the install script when cloudshell button is pressed
 }

--- a/terraform/telemetry.py
+++ b/terraform/telemetry.py
@@ -52,7 +52,7 @@ def get_telemetry_msg(session, project_id, event, version):
 # returns False along with an error message if not
 def validate_args(session, project_id, event, version):
     args_exp = {
-        "version": r"^v\d.\d.\d$",
+        "version": r"^(v\d.\d.\d|develop)$",
         "project_id": r"^cloud-ops-sandbox-(\d){6,12}$",
         "v4uuid": r"^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}$"
     }


### PR DESCRIPTION
- Telemetry isn't being sent on develop due to a regex check. We now want to accept "develop" as a valid version field
- Telemetry isn't being set on `main` due to the version environment variable not being found. It looks like recent versions of the cloud shell container stopped sourcing `/etc/environment`. This PR adds this back to the cloud shell run steps