### PR TITLE
tests: Add integration tests for validating SRE Recipe config schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
         if [[ -n $(git status -s) ]]; then
           exit 1
         fi
+    - name: Validate Schema of SRE Recipes Configs
+      run: |
+        set -x
+        # install dependencies
+        python3 -m ensurepip --upgrade
+        python3 -m pip install -r tests/requirements.txt
+        # run validations
+        python tests/recipes/validate_recipe_configs.py
     - name: Test Custom Cloud Shell Image Build
       run: |
         set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         python3 get-pip.py
         python3 -m pip install -r tests/requirements.txt
         # run validations
-        python tests/recipes/validate_recipe_configs.py
+        python3 tests/recipes/validate_recipe_configs.py
     - name: Test Custom Cloud Shell Image Build
       run: |
         set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
       run: |
         set -x
         # install dependencies
-        python3 -m ensurepip --upgrade
+        curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o get-pip.py
+        python3 get-pip.py
         python3 -m pip install -r tests/requirements.txt
         # run validations
         python tests/recipes/validate_recipe_configs.py

--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -54,14 +54,6 @@ jobs:
         IMAGE_PATH=gcr.io/${{ env.PROJECT_ID }}/tests/gcr.io/stackdriver-sandbox-230822/sandbox/loadgenerator/gke:$GITHUB_SHA
         docker build -t $IMAGE_PATH ./src/loadgenerator
         docker push $IMAGE_PATH
-    - name: Validate SRE Recipes Configs
-      timeout-minutes: 30
-      run: |
-        set -x
-        # install dependencies
-        python3 -m pip install -r tests/requirements.txt
-        # run validations
-        python3 tests/recipes/validate_recipe_configs.py
     - name: Rewrite Manifests
       run: |
         set -x

--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -95,6 +95,14 @@ jobs:
           -e LOADGEN_ZONE=$LOADGEN_ZONE \
           -v ~/.config:/root/.config \
           test-provisioning:$GITHUB_SHA
+    - name: Run SRE Recipes Config Validations
+      timeout-minutes: 30
+      run: |
+        set -x
+        # install dependencies
+        python3 -m pip install -r tests/requirements.txt
+        # run validations
+        python3 tests/recipes/validate_recipe_configs.py
     - name: Run SRE Recipes Tests
       timeout-minutes: 30
       run: |

--- a/.github/workflows/e2e-latest.yml
+++ b/.github/workflows/e2e-latest.yml
@@ -54,6 +54,14 @@ jobs:
         IMAGE_PATH=gcr.io/${{ env.PROJECT_ID }}/tests/gcr.io/stackdriver-sandbox-230822/sandbox/loadgenerator/gke:$GITHUB_SHA
         docker build -t $IMAGE_PATH ./src/loadgenerator
         docker push $IMAGE_PATH
+    - name: Validate SRE Recipes Configs
+      timeout-minutes: 30
+      run: |
+        set -x
+        # install dependencies
+        python3 -m pip install -r tests/requirements.txt
+        # run validations
+        python3 tests/recipes/validate_recipe_configs.py
     - name: Rewrite Manifests
       run: |
         set -x
@@ -95,14 +103,6 @@ jobs:
           -e LOADGEN_ZONE=$LOADGEN_ZONE \
           -v ~/.config:/root/.config \
           test-provisioning:$GITHUB_SHA
-    - name: Run SRE Recipes Config Validations
-      timeout-minutes: 30
-      run: |
-        set -x
-        # install dependencies
-        python3 -m pip install -r tests/requirements.txt
-        # run validations
-        python3 tests/recipes/validate_recipe_configs.py
     - name: Run SRE Recipes Tests
       timeout-minutes: 30
       run: |

--- a/sre-recipes/README.md
+++ b/sre-recipes/README.md
@@ -28,4 +28,12 @@ $ ./sandboxctl sre-recipes hint <recipe_name>
 
 ## Contributing
 
-To contribute a new recipe, create a new folder in the [recipes directory](./recipes). The directory must include a class that extends the abstract base class found in [recipe.py](recipe.py).
+To contribute a new recipe, you can either:
+
+1. Create a simple config based SRE Recipe (Recommended)
+    
+   See `recipes/configs_based/README.md` for contribution instruction and usage.
+
+2. Create a implementation based SRE Recipe class
+    
+   See `recipes/impl_based/README.md` for contribution instruction and usage.

--- a/sre-recipes/recipes/configs_based/README.md
+++ b/sre-recipes/recipes/configs_based/README.md
@@ -71,6 +71,14 @@ config:
         - option: Answer 3
 ```
 
+## Contributions
+
+If you want to add more pre-defined action templates,
+
+1. add your implementation to the `ActionHandlers` in `recipe_runner.py`.
+2. add a short guide for how to use your new action in this README file
+3. add schema validation for your new action config in `./schema` folder
+
 ## Supported SRE Recipe Actions
 
 The `break` and `restore` sections support the following action templates:
@@ -137,8 +145,3 @@ Example
     - option: Answer 2
     - option: Answer 3
 ```
-
-**Contributions**
-
-If you want to add more pre-defined action templates, add your implementation to
-the `ActionHandlers` in `recipe_runner.py`.

--- a/sre-recipes/recipes/configs_based/recipe2.yaml
+++ b/sre-recipes/recipes/configs_based/recipe2.yaml
@@ -50,7 +50,7 @@ config:
         - option: Rating
           accept: true
         - option: Recommendation
-        - option: Shipping #
+        - option: Shipping
     - action: multiple-choice-quiz
       prompt: What was the cause of the issue?
       choices:

--- a/sre-recipes/recipes/configs_based/schema/README.md
+++ b/sre-recipes/recipes/configs_based/schema/README.md
@@ -1,0 +1,61 @@
+## Config Based SRE Recipe Schema
+
+This directory defines the schema validation for SRE Recipes configs.
+
+It uses the JSON Schema (https://json-schema.org/) definition based the parsed
+JSON from the YAML format.
+
+### Usage
+
+If you need to write reusable schema definitions that can be referenced via
+`$ref` field, define them in the `./defs` subdirectory. See the README there for
+more details.
+
+### Adding validation for a new SRE Recipe action
+
+1. Define the JSON schema for your action config under `./defs`.
+
+   For example, our `loadgen-spawn` action config schema validation are defined
+   at `./defs/loadgen-spawn.schema.json`
+
+2. Add your new action to the `./defs/action-config-list.schema.json` schema
+
+   a. Add your action config name to the list of `enums` under `Supported action configs names`.
+   b. Attach your schema definition reference to the config name by adding a new tuple under `allOf`.
+
+For example, if you added a new action handler for `action: my-action`, then:
+
+1. create a `./defs/my-action.schema.json` schema definition
+2. add to the `action-config-list.schema.json`:
+
+```json
+{
+  // other stuff ....
+  "items": {
+    "properties": {
+      "action": {
+        "type": "string",
+        "description": "Supported action configs names",
+        "enum": [
+          // other stuff ....
+          "my-action" // step a: add your action name here
+        ]
+      }
+    },
+    "allOf": [
+      // ....
+      // step b: attach your schema definition here
+      {
+        "description": "The schema definition for `action: my-action`",
+        "if": {
+          "properties": { "action": { "const": "my-action" } }
+        },
+        "then": {
+          "$ref": "#/$defs/my-action"
+        }
+      }
+    ]
+  },
+  // other stuff ....
+}
+```

--- a/sre-recipes/recipes/configs_based/schema/README.md
+++ b/sre-recipes/recipes/configs_based/schema/README.md
@@ -8,8 +8,7 @@ JSON from the YAML format.
 ### Usage
 
 If you need to write reusable schema definitions that can be referenced via
-`$ref` field, define them in the `./defs` subdirectory. See the README there for
-more details.
+`$ref` field, define them in the `./defs` subdirectory.
 
 ### Adding validation for a new SRE Recipe action
 
@@ -21,14 +20,15 @@ more details.
 2. Add your new action to the `./defs/action-config-list.schema.json` schema
 
    a. Add your action config name to the list of `enums` under `Supported action configs names`.
-   b. Attach your schema definition reference to the config name by adding a new tuple under `allOf`.
+
+   b. Attach your schema definition reference to the config name by adding a new `if-then` tuple under `allOf`.
 
 For example, if you added a new action handler for `action: my-action`, then:
 
 1. create a `./defs/my-action.schema.json` schema definition
 2. add to the `action-config-list.schema.json`:
 
-```json
+```
 {
   // other stuff ....
   "items": {

--- a/sre-recipes/recipes/configs_based/schema/defs/README.md
+++ b/sre-recipes/recipes/configs_based/schema/defs/README.md
@@ -1,0 +1,61 @@
+# JSON Schema Definitions
+
+This directory contains all the JSON schema definitions that will be pulled into
+the root `$def` section of the main root schema at `schema.json` (in the parent
+directory) for reference at SRE Recipe validation schema bundling time.
+
+**Requirements**
+
+1. All schema definitions should follow the naming convention of `ABC.schema.json`
+2. The individual schema definition file should NOT define its own `definitions`
+   or `$defs` sections. If you need to reuse certain schema definition, make
+   it a new schema definition file on its own.
+
+For a definition file named `ABC.schema.json`, it can be referenced by
+`#/$defs/abc` by both the root `schema.json` and any other definition file
+under this `./defs` directory.
+
+### Example
+
+- `schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema.json",
+  "type": "object",
+  "properties": {
+    "first-name": {
+      "$ref": "#/$defs/name"
+    },
+    "last-name": {
+      "$ref": "#/$defs/name"
+    },
+    "age": {
+      "$ref": "#/$defs/age"
+    }
+  }
+}
+```
+
+- `defs/name.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "name.schema.json",
+  "type": "string",
+  "minLength": 1
+}
+```
+
+- `defs/age.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "age.schema.json",
+  "type": "integer",
+  "minimum": 1
+}
+```

--- a/sre-recipes/recipes/configs_based/schema/defs/action-config-list.schema.json
+++ b/sre-recipes/recipes/configs_based/schema/defs/action-config-list.schema.json
@@ -1,0 +1,57 @@
+{
+  "type": "array",
+  "description": "The main schema for defining a list of action configs",
+  "items": {
+    "properties": {
+      "action": {
+        "type": "string",
+        "description": "Supported action configs names",
+        "enum": [
+          "run-shell-commands",
+          "loadgen-spawn",
+          "loadgen-stop",
+          "multiple-choice-quiz"
+        ]
+      }
+    },
+    "allOf": [
+      {
+        "description": "The schema definition for `action: run-shell-commands`",
+        "if": {
+          "properties": { "action": { "const": "run-shell-commands" } }
+        },
+        "then": {
+          "$ref": "#/$defs/run-shell-commands"
+        }
+      },
+      {
+        "description": "The schema definition for `action: loadgen-spawn`",
+        "if": {
+          "properties": { "action": { "const": "loadgen-spawn" } }
+        },
+        "then": {
+          "$ref": "#/$defs/loadgen-spawn"
+        }
+      },
+      {
+        "description": "The schema definition for `action: loadgen-stop`",
+        "if": {
+          "properties": { "action": { "const": "loadgen-stop" } }
+        },
+        "then": {
+          "$ref": "#/$defs/loadgen-stop"
+        }
+      },
+      {
+        "description": "The schema definition for `action: multiple-choice-quiz`",
+        "if": {
+          "properties": { "action": { "const": "multiple-choice-quiz" } }
+        },
+        "then": {
+          "$ref": "#/$defs/multiple-choice-quiz"
+        }
+      }
+    ]
+  },
+  "minItems": 1
+}

--- a/sre-recipes/recipes/configs_based/schema/defs/loadgen-spawn.schema.json
+++ b/sre-recipes/recipes/configs_based/schema/defs/loadgen-spawn.schema.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "description": "The config schema for generating a specific load pattern to the sandbox frontend.",
+  "required": ["action"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "const": "loadgen-spawn",
+      "description": "Required identifier for loadgen-spawn action."
+    },
+    "user_type": {
+      "type": "string",
+      "description": "Optional. The `sre_recipe_user_identifier` for locust tasks defined in `sre/loadgenerator/locust_tasks`. Default: BasicHomePageViewingUser.",
+      "minLength": 1
+    },
+    "user_count": {
+      "type": "integer",
+      "description": "Optional. The number of total users to spawn. Default: 20.",
+      "minimum": 1
+    },
+    "spawn_rate": {
+      "type": "integer",
+      "description": "Optional. The number of users per second to spawn. Default: 1.",
+      "minimum": 1
+    },
+    "stop_after": {
+      "type": "integer",
+      "description": "Optional. The number of seconds to spawn before stopping. Default: 600.",
+      "minimum": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/sre-recipes/recipes/configs_based/schema/defs/loadgen-stop.schema.json
+++ b/sre-recipes/recipes/configs_based/schema/defs/loadgen-stop.schema.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "description": "The config schema for stopping any active load generation produced by SRE Recipe Load Generator.",
+  "required": ["action"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "const": "loadgen-stop",
+      "description": "Required identifier for loadgen-stop action."
+    }
+  },
+  "additionalProperties": false
+}

--- a/sre-recipes/recipes/configs_based/schema/defs/multiple-choice-quiz.schema.json
+++ b/sre-recipes/recipes/configs_based/schema/defs/multiple-choice-quiz.schema.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "description": "The config schema for running an interactive multiple choice quiz.",
+  "required": ["action", "prompt", "choices"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "const": "multiple-choice-quiz",
+      "description": "Required identifier for multiple-choice-quiz action."
+    },
+    "prompt": {
+      "type": "string",
+      "description": "Required. The question prompt to display.",
+      "minLength": 1
+    },
+    "choices": {
+      "type": "array",
+      "description": "Required. The list of potential answers to choose from.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "description": "The config schema for a specific answer choice",
+        "required": ["option"],
+        "properties": {
+          "option": {
+            "type": "string",
+            "description": "Required. The answer display text to show user."
+          },
+          "accept": {
+            "type": "boolean",
+            "description": "Optional. When true, this entry will be accepted as correct."
+          }
+        },
+        "additionalProperties": false
+      },
+      "contains": {
+        "type": "object",
+        "description": "At least one answer config has `accept` defined as True.",
+        "required": ["accept"],
+        "properties": {
+          "accept": {
+            "type": "boolean",
+            "enum": [true]
+          }
+        }
+      },
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/sre-recipes/recipes/configs_based/schema/defs/run-shell-commands.schema.json
+++ b/sre-recipes/recipes/configs_based/schema/defs/run-shell-commands.schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "description": "The config schema for running a list of shell commands one at a time",
+  "required": ["action", "commands"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "const": "run-shell-commands",
+      "description": "Required identifier for run-shell-commands action."
+    },
+    "commands": {
+      "type": "array",
+      "description": "Required. A list of shell command strings",
+      "items": {
+        "type": "string",
+        "description": "Valid command string passed to Python `subprocess.run`",
+        "minLength": 1
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/sre-recipes/recipes/configs_based/schema/schema.json
+++ b/sre-recipes/recipes/configs_based/schema/schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "schema.json",
+  "title": "SRE Recipe Config - Schema Definitions",
   "type": "object",
   "description": "The base schema for an SRE Recipe",
   "required": ["name", "description", "config"],
@@ -22,11 +23,11 @@
       "properties": {
         "break": {
           "description": "A list of actions to run for the `sandboxctl sre-receipes break` command",
-          "$ref": "#/$defs/actions-list"
+          "$ref": "#/$defs/action-config-list"
         },
         "restore": {
           "description": "A list of actions to run for the `sandboxctl sre-receipes restore` command",
-          "$ref": "#/$defs/actions-list"
+          "$ref": "#/$defs/action-config-list"
         },
         "hint": {
           "type": "string",
@@ -35,187 +36,11 @@
         },
         "verify": {
           "description": "A list of actions to run for the `sandboxctl sre-receipes verify` command",
-          "$ref": "#/$defs/actions-list"
+          "$ref": "#/$defs/action-config-list"
         }
       },
       "additionalProperties": false
     }
   },
-  "additionalProperties": false,
-  "$defs": {
-    "actions-list": {
-      "type": "array",
-      "description": "The main schema for defining a list of action configs",
-      "items": {
-        "allOf": [
-          {
-            "properties": {
-              "action": {
-                "type": "string",
-                "description": "Only support following action configs",
-                "enum": [
-                  "run-shell-commands",
-                  "loadgen-spawn",
-                  "loadgen-stop",
-                  "multiple-choice-quiz"
-                ]
-              }
-            }
-          },
-          {
-            "if": {
-              "properties": { "action": { "const": "run-shell-commands" } }
-            },
-            "then": {
-              "$ref": "#/$defs/run-shell-commands"
-            }
-          },
-          {
-            "if": {
-              "properties": { "action": { "const": "loadgen-spawn" } }
-            },
-            "then": {
-              "$ref": "#/$defs/loadgen-spawn"
-            }
-          },
-          {
-            "if": {
-              "properties": { "action": { "const": "loadgen-stop" } }
-            },
-            "then": {
-              "$ref": "#/$defs/loadgen-stop"
-            }
-          },
-          {
-            "if": {
-              "properties": { "action": { "const": "multiple-choice-quiz" } }
-            },
-            "then": {
-              "$ref": "#/$defs/multiple-choice-quiz"
-            }
-          }
-        ]
-      },
-      "minItems": 1
-    },
-    "run-shell-commands": {
-      "type": "object",
-      "description": "The config schema for running a list of shell commands one at a time",
-      "required": ["action", "commands"],
-      "properties": {
-        "action": {
-          "type": "string",
-          "const": "run-shell-commands",
-          "description": "Required. Identifier for this specific action."
-        },
-        "commands": {
-          "type": "array",
-          "description": "Required. A list of shell command strings",
-          "items": {
-            "type": "string",
-            "description": "Valid command string passed to Python `subprocess.run`",
-            "minLength": 1
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    "loadgen-spawn": {
-      "type": "object",
-      "description": "The config schema for generating a specific load pattern to the sandbox frontend.",
-      "required": ["action"],
-      "properties": {
-        "action": {
-          "type": "string",
-          "const": "loadgen-spawn",
-          "description": "Required. Identifier for this specific action."
-        },
-        "user_type": {
-          "type": "string",
-          "description": "Optional. The `sre_recipe_user_identifier` for locust tasks defined in `sre/loadgenerator/locust_tasks`. Default: BasicHomePageViewingUser.",
-          "minLength": 1
-        },
-        "user_count": {
-          "type": "integer",
-          "description": "Optional. The number of total users to spawn. Default: 20.",
-          "minimum": 1
-        },
-        "spawn_rate": {
-          "type": "integer",
-          "description": "Optional. The number of users per second to spawn. Default: 1.",
-          "minimum": 1
-        },
-        "stop_after": {
-          "type": "integer",
-          "description": "Optional. The number of seconds to spawn before stopping. Default: 600.",
-          "minimum": 1
-        }
-      },
-      "additionalProperties": false
-    },
-    "loadgen-stop": {
-      "type": "object",
-      "description": "The config schema for stopping any active load generation produced by SRE Recipe Load Generator.",
-      "required": ["action"],
-      "properties": {
-        "action": {
-          "type": "string",
-          "const": "loadgen-stop",
-          "description": "Required. Identifier for this specific action."
-        }
-      },
-      "additionalProperties": false
-    },
-    "multiple-choice-quiz": {
-      "type": "object",
-      "description": "The config schema for running an interactive multiple choice quiz.",
-      "required": ["action", "prompt", "choices"],
-      "properties": {
-        "action": {
-          "type": "string",
-          "const": "multiple-choice-quiz",
-          "description": "Required. Identifier for this specific action."
-        },
-        "prompt": {
-          "type": "string",
-          "description": "Required. The question prompt to display.",
-          "minLength": 1
-        },
-        "choices": {
-          "type": "array",
-          "description": "Required. The list of potential answers to choose from.",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "description": "The config schema for a specific answer choice",
-            "required": ["option"],
-            "properties": {
-              "option": {
-                "type": "string",
-                "description": "Required. The answer display text to show user."
-              },
-              "accept": {
-                "type": "boolean",
-                "description": "Optional. When true, this entry will be accepted as correct."
-              }
-            },
-            "additionalProperties": false
-          },
-          "contains": {
-            "type": "object",
-            "description": "At least one answer config has `accept` defined as True.",
-            "required": ["accept"],
-            "properties": {
-              "accept": {
-                "type": "boolean",
-                "enum": [true]
-              }
-            }
-          },
-          "uniqueItems": true
-        }
-      },
-      "additionalProperties": false
-    }
-  }
+  "additionalProperties": false
 }

--- a/sre-recipes/recipes/configs_based/schema/schema.json
+++ b/sre-recipes/recipes/configs_based/schema/schema.json
@@ -1,0 +1,221 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema.json",
+  "type": "object",
+  "description": "The base schema for an SRE Recipe",
+  "required": ["name", "description", "config"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the SRE Recipe",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "description": "The description of the SRE Recipe",
+      "minLength": 1
+    },
+    "config": {
+      "type": "object",
+      "description": "The config section for the SRE Recipe",
+      "required": ["break", "restore", "hint", "verify"],
+      "properties": {
+        "break": {
+          "description": "A list of actions to run for the `sandboxctl sre-receipes break` command",
+          "$ref": "#/$defs/actions-list"
+        },
+        "restore": {
+          "description": "A list of actions to run for the `sandboxctl sre-receipes restore` command",
+          "$ref": "#/$defs/actions-list"
+        },
+        "hint": {
+          "type": "string",
+          "description": "A list of actions to run for the `sandboxctl sre-receipes hint` command",
+          "minLength": 1
+        },
+        "verify": {
+          "description": "A list of actions to run for the `sandboxctl sre-receipes verify` command",
+          "$ref": "#/$defs/actions-list"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "actions-list": {
+      "type": "array",
+      "description": "The main schema for defining a list of action configs",
+      "items": {
+        "allOf": [
+          {
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Only support following action configs",
+                "enum": [
+                  "run-shell-commands",
+                  "loadgen-spawn",
+                  "loadgen-stop",
+                  "multiple-choice-quiz"
+                ]
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": { "action": { "const": "run-shell-commands" } }
+            },
+            "then": {
+              "$ref": "#/$defs/run-shell-commands"
+            }
+          },
+          {
+            "if": {
+              "properties": { "action": { "const": "loadgen-spawn" } }
+            },
+            "then": {
+              "$ref": "#/$defs/loadgen-spawn"
+            }
+          },
+          {
+            "if": {
+              "properties": { "action": { "const": "loadgen-stop" } }
+            },
+            "then": {
+              "$ref": "#/$defs/loadgen-stop"
+            }
+          },
+          {
+            "if": {
+              "properties": { "action": { "const": "multiple-choice-quiz" } }
+            },
+            "then": {
+              "$ref": "#/$defs/multiple-choice-quiz"
+            }
+          }
+        ]
+      },
+      "minItems": 1
+    },
+    "run-shell-commands": {
+      "type": "object",
+      "description": "The config schema for running a list of shell commands one at a time",
+      "required": ["action", "commands"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "run-shell-commands",
+          "description": "Required. Identifier for this specific action."
+        },
+        "commands": {
+          "type": "array",
+          "description": "Required. A list of shell command strings",
+          "items": {
+            "type": "string",
+            "description": "Valid command string passed to Python `subprocess.run`",
+            "minLength": 1
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "loadgen-spawn": {
+      "type": "object",
+      "description": "The config schema for generating a specific load pattern to the sandbox frontend.",
+      "required": ["action"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "loadgen-spawn",
+          "description": "Required. Identifier for this specific action."
+        },
+        "user_type": {
+          "type": "string",
+          "description": "Optional. The `sre_recipe_user_identifier` for locust tasks defined in `sre/loadgenerator/locust_tasks`. Default: BasicHomePageViewingUser.",
+          "minLength": 1
+        },
+        "user_count": {
+          "type": "integer",
+          "description": "Optional. The number of total users to spawn. Default: 20.",
+          "minimum": 1
+        },
+        "spawn_rate": {
+          "type": "integer",
+          "description": "Optional. The number of users per second to spawn. Default: 1.",
+          "minimum": 1
+        },
+        "stop_after": {
+          "type": "integer",
+          "description": "Optional. The number of seconds to spawn before stopping. Default: 600.",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "loadgen-stop": {
+      "type": "object",
+      "description": "The config schema for stopping any active load generation produced by SRE Recipe Load Generator.",
+      "required": ["action"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "loadgen-stop",
+          "description": "Required. Identifier for this specific action."
+        }
+      },
+      "additionalProperties": false
+    },
+    "multiple-choice-quiz": {
+      "type": "object",
+      "description": "The config schema for running an interactive multiple choice quiz.",
+      "required": ["action", "prompt", "choices"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "multiple-choice-quiz",
+          "description": "Required. Identifier for this specific action."
+        },
+        "prompt": {
+          "type": "string",
+          "description": "Required. The question prompt to display.",
+          "minLength": 1
+        },
+        "choices": {
+          "type": "array",
+          "description": "Required. The list of potential answers to choose from.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "description": "The config schema for a specific answer choice",
+            "required": ["option"],
+            "properties": {
+              "option": {
+                "type": "string",
+                "description": "Required. The answer display text to show user."
+              },
+              "accept": {
+                "type": "boolean",
+                "description": "Optional. When true, this entry will be accepted as correct."
+              }
+            },
+            "additionalProperties": false
+          },
+          "contains": {
+            "type": "object",
+            "description": "At least one answer config has `accept` defined as True.",
+            "required": ["accept"],
+            "properties": {
+              "accept": {
+                "type": "boolean",
+                "enum": [true]
+              }
+            }
+          },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/sre-recipes/recipes/configs_based/schema/schema.json
+++ b/sre-recipes/recipes/configs_based/schema/schema.json
@@ -31,7 +31,7 @@
         },
         "hint": {
           "type": "string",
-          "description": "A list of actions to run for the `sandboxctl sre-receipes hint` command",
+          "description": "A hint string to display for the `sandboxctl sre-receipes hint` command",
           "minLength": 1
         },
         "verify": {

--- a/sre-recipes/requirements.txt
+++ b/sre-recipes/requirements.txt
@@ -1,4 +1,3 @@
 click>=7.1.0
 pyyaml>-5.4.1
 requests>=2.24.0
-jsonschema

--- a/sre-recipes/requirements.txt
+++ b/sre-recipes/requirements.txt
@@ -1,3 +1,4 @@
 click>=7.1.0
 pyyaml>-5.4.1
 requests>=2.24.0
+jsonschema

--- a/tests/recipes/validate_recipe_configs.py
+++ b/tests/recipes/validate_recipe_configs.py
@@ -6,14 +6,14 @@ import jsonschema
 
 RECIPES_ROOT = os.path.join(os.path.dirname(
     os.path.abspath(__file__)), "../../sre-recipes/recipes/configs_based")
-SCHEMA_ROOT = f"{RECIPES_ROOT}/schema"
+SCHEMA_ROOT = RECIPES_ROOT + "/schema"
 
 print("Loading base schema...")
-with open(f"{SCHEMA_ROOT}/schema.json", "r") as file:
+with open(SCHEMA_ROOT + "/schema.json", "r") as file:
     schema = json.load(file)
 
 print("Bundling additional schema definitions...")
-for def_path in glob.glob(f"{SCHEMA_ROOT}/defs/*.schema.json"):
+for def_path in glob.glob(SCHEMA_ROOT + "/defs/*.schema.json"):
     def_name = os.path.basename(def_path).split(".")[0]
     with open(def_path, "r") as def_file:
         def_schema = json.load(def_file)
@@ -23,22 +23,22 @@ for def_path in glob.glob(f"{SCHEMA_ROOT}/defs/*.schema.json"):
 
 print("Running validations on all SRE recipe configs...")
 has_error = False
-for recipe_path in glob.glob(f"{RECIPES_ROOT}/*.yaml"):
+for recipe_path in glob.glob(RECIPES_ROOT + "/*.yaml"):
     recipe_name = os.path.basename(recipe_path).split(".")[0]
-    print(f"Validating {recipe_name}")
+    print("Validating:", recipe_name)
     with open(recipe_path, "r") as recipe_file:
         try:
             recipe_config = yaml.load(
                 recipe_file.read(), Loader=yaml.FullLoader)
         except Exception as e:
-            print(f"Invalid or empty YAML: {e}")
+            print("Invalid or empty YAML:", e)
             has_error = True
             continue
     try:
         jsonschema.validate(recipe_config, schema)
-        print(f"{recipe_name} is valid!")
+        print("Valid!")
     except Exception as e:
-        print(f"{recipe_name} failed validation!\n {e}")
+        print("Invalid!", e)
         has_error = True
 
 if has_error:

--- a/tests/recipes/validate_recipe_configs.py
+++ b/tests/recipes/validate_recipe_configs.py
@@ -1,3 +1,19 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- coding: utf-8 -*-
+
 import os
 import json
 import yaml

--- a/tests/recipes/validate_recipe_configs.py
+++ b/tests/recipes/validate_recipe_configs.py
@@ -1,0 +1,46 @@
+import os
+import json
+import yaml
+import glob
+import jsonschema
+
+RECIPES_ROOT = os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), "../../sre-recipes/recipes/configs_based")
+SCHEMA_ROOT = f"{RECIPES_ROOT}/schema"
+
+print("Loading base schema...")
+with open(f"{SCHEMA_ROOT}/schema.json", "r") as file:
+    schema = json.load(file)
+
+print("Bundling additional schema definitions...")
+for def_path in glob.glob(f"{SCHEMA_ROOT}/defs/*.schema.json"):
+    def_name = os.path.basename(def_path).split(".")[0]
+    with open(def_path, "r") as def_file:
+        def_schema = json.load(def_file)
+    if "$defs" not in schema:
+        schema["$defs"] = {}
+    schema["$defs"][def_name] = def_schema
+
+print("Running validations on all SRE recipe configs...")
+has_error = False
+for recipe_path in glob.glob(f"{RECIPES_ROOT}/*.yaml"):
+    recipe_name = os.path.basename(recipe_path).split(".")[0]
+    print(f"Validating {recipe_name}")
+    with open(recipe_path, "r") as recipe_file:
+        try:
+            recipe_config = yaml.load(
+                recipe_file.read(), Loader=yaml.FullLoader)
+        except Exception as e:
+            print(f"Invalid or empty YAML: {e}")
+            has_error = True
+            continue
+    try:
+        jsonschema.validate(recipe_config, schema)
+        print(f"{recipe_name} is valid!")
+    except Exception as e:
+        print(f"{recipe_name} failed validation!\n {e}")
+        has_error = True
+
+if has_error:
+    print("ERROR. At least one SRE Recipe config is invalid.")
+    exit(1)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ google-cloud-monitoring-dashboards>=1.0.0
 tabulate>=0.8.7
 google-api-python-client>=1.10.0
 oauth2client>=4.1.3
+jsonschema>=3.2.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ tabulate>=0.8.7
 google-api-python-client>=1.10.0
 oauth2client>=4.1.3
 jsonschema>=3.2.0
+pyyaml>-5.4.1


### PR DESCRIPTION
The validation mainly relies on the newest JSON Schema (https://json-schema.org) definition, and it works by first converting the YAML config to JSON, and then validate directly on the converted JSON. Added relevant README changes as well.

In order to make decoupling JSON schema easier, I decided to write a custom schema bundling logic for schema "references", since the Python version of the JSON schema validator doesn't support referencing local files well.