### PR TITLE
fix: pin terraform providers to specific version

### DIFF
--- a/terraform/01_provider.tf
+++ b/terraform/01_provider.tf
@@ -28,7 +28,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">=3.23.0"
+      version = "=3.90.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google"
+      version = "=3.90.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
we're seeing sandbox failures now that the google-beta provider updated to v4.x. This PR pins it to the last known working version (v3.90.0), rather than accepting arbitrary updates