### PR TITLE
fix: rating service dependencies

### DIFF
--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -19,7 +19,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python \
+    python3 \
     make \
     g++
 

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -18,7 +18,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python \
+    python3 \
     make \
     g++ 
 

--- a/src/ratingservice/requirements.txt
+++ b/src/ratingservice/requirements.txt
@@ -1,4 +1,5 @@
 uwsgi==2.0.19.1
 flask==1.1.4
 psycopg2-binary==2.8.5
-google-python-cloud-debugger
+google-python-cloud-debugger=2.17
+pyparsing==2.4.7

--- a/src/ratingservice/requirements.txt
+++ b/src/ratingservice/requirements.txt
@@ -1,5 +1,5 @@
 uwsgi==2.0.19.1
 flask==1.1.4
 psycopg2-binary==2.8.5
-google-python-cloud-debugger=2.17
+google-python-cloud-debugger==2.18
 pyparsing==2.4.7

--- a/src/ratingservice/requirements.txt
+++ b/src/ratingservice/requirements.txt
@@ -2,4 +2,5 @@ uwsgi==2.0.19.1
 flask==1.1.4
 psycopg2-binary==2.8.5
 google-python-cloud-debugger==2.18
+# pyparsing pin solves related issue: https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/877
 pyparsing==2.4.7


### PR DESCRIPTION
The rating service recently started to break deployment, due to a new dependency issue. This PR pins pyparsing, which should fix the issue

Fixes https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/877