### PR TITLE
security: update the log4j version to latest

### DIFF
--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -45,7 +45,7 @@ dependencies {
                 "io.grpc:grpc-stub:${grpcVersion}",
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
-                "org.apache.logging.log4j:log4j-core:2.13.3"
+                "org.apache.logging.log4j:log4j-core:2.15.0"
 
         runtimeOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",


### PR DESCRIPTION
### Fixes #883
- Update the log4j version to `2.15.0` in all microservices used by the sandbox project.
- Ideally it would be best to do a new release of it and notify all stakeholders who might be using the app in various settings