### PR TITLE
fix: CVE-2021-44228

### DIFF
--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -45,7 +45,7 @@ dependencies {
                 "io.grpc:grpc-stub:${grpcVersion}",
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
-                "org.apache.logging.log4j:log4j-core:2.13.3"
+                "org.apache.logging.log4j:log4j-core:2.15.0"
 
         runtimeOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",


### PR DESCRIPTION
upgrade log4j2 package to 2.15.0 that fixes the ZD CVE-2021-44228