### PR TITLE
chore: update "open in cloud shell links" to use new format

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -74,6 +74,8 @@ jobs:
           sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/website/deploy/index.html;
           sed -i -e "s/productVersion': 'v\([0-9\.]\+\)/productVersion': '${NEW_VERSION}/g" ${REPO_ROOT}/website/deploy/index.html;
           sed -i -e "s/uncertified:v\([0-9\.]\+\)/uncertified:${NEW_VERSION}/g" ${REPO_ROOT}/website/deploy/index.html;
+          sed -i -e "s/uncertified:v\([0-9\.]\+\)/uncertified:${NEW_VERSION}/g" ${REPO_ROOT}/website/deploy/docs/_print/index.html;
+          sed -i -e "s/uncertified:v\([0-9\.]\+\)/uncertified:${NEW_VERSION}/g" ${REPO_ROOT}/website/deploy/docs/getting_started/index.html;
           sed -i -e "s/version = \"v\([0-9\.]\+\)\"/version = \"${NEW_VERSION}\"/g" ${REPO_ROOT}/website/config.toml;
           # update custom Cloud Shell image variable
           sed -i -e "s/VERSION=v\([0-9\.]\+\)/VERSION=${NEW_VERSION}/g" ${REPO_ROOT}/cloud-shell/Dockerfile;

--- a/.github/workflows/pr-comment-bot.yml
+++ b/.github/workflows/pr-comment-bot.yml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           msg: |
-            [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/${{ github.repository  }}.git&cloudshell_git_branch=${{ github.head_ref }}&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:latest)
+            [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/${{ github.repository  }}.git&cloudshell_git_branch=${{ github.head_ref }}&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:latest)
             You can also use the [Stage Website Action](https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/actions/workflows/manual-website-stage.yml) if there were updates to the website.
             ---
             > Note: Open in Cloud Shell may not work properly if this PR contains changes to the custom Cloud Shell image

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,6 +350,6 @@ gcr.io/[PROJECT_ID]/[IMAGE]
 When developing sandbox, it can be useful to launch a new Cloud Shell session straight from your branch. You can do this by modifying
 and opening the following url:
 
-https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=**your-branch-here**&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:latest
+https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=**your-branch-here**&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:latest
 
 When you're ready to open a PR, a GitHub Actions bot will attach an Open in Cloud Shell button directing to your changes automatically

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 
 Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
 
-[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=develop&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:latest&cloudshell_tutorial=docs/tutorial.md)
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=develop&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:latest&cloudshell_tutorial=docs/tutorial.md)
 
 __Note__: If installation stops due to billing account errors, set up the billing account and type: `sandboxctl create`.
 

--- a/website/content/en/docs/getting_started.md
+++ b/website/content/en/docs/getting_started.md
@@ -25,7 +25,7 @@ weight: 2
 
 Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
 
-[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.6.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.6.0&cloudshell_tutorial=docs/tutorial.md)
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.6.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.6.0&cloudshell_tutorial=docs/tutorial.md)
 
 __Note__: If installation stops due to billing account errors, set up the billing account and type: `sandboxctl create`.
 

--- a/website/deploy/docs/_print/index.html
+++ b/website/deploy/docs/_print/index.html
@@ -412,7 +412,7 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 </ul>
 <h3 id="set-up">Set Up</h3>
 <p>Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.</p>
-<p><a href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&amp;cloudshell_git_branch=v0.6.0&amp;shellonly=true&amp;cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.6.0&amp;cloudshell_tutorial=docs/tutorial.md"><img src="http://www.gstatic.com/cloudssh/images/open-btn.svg" alt="Open in Cloud Shell"></a></p>
+<p><a href="https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&amp;cloudshell_git_branch=v0.7.5&amp;shellonly=true&amp;cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.7.5&amp;cloudshell_tutorial=docs/tutorial.md"><img src="http://www.gstatic.com/cloudssh/images/open-btn.svg" alt="Open in Cloud Shell"></a></p>
 <p><strong>Note</strong>: If installation stops due to billing account errors, set up the billing account and type: <code>sandboxctl create</code>.</p>
 <h3 id="next-steps">Next Steps</h3>
 <ul>

--- a/website/deploy/docs/getting_started/index.html
+++ b/website/deploy/docs/getting_started/index.html
@@ -509,7 +509,7 @@ if (!doNotTrack) {
 </ul>
 <h3 id="set-up">Set Up</h3>
 <p>Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.</p>
-<p><a href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&amp;cloudshell_git_branch=v0.6.0&amp;shellonly=true&amp;cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.6.0&amp;cloudshell_tutorial=docs/tutorial.md"><img src="http://www.gstatic.com/cloudssh/images/open-btn.svg" alt="Open in Cloud Shell"></a></p>
+<p><a href="https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&amp;cloudshell_git_branch=v0.7.5&amp;shellonly=true&amp;cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.7.5&amp;cloudshell_tutorial=docs/tutorial.md"><img src="http://www.gstatic.com/cloudssh/images/open-btn.svg" alt="Open in Cloud Shell"></a></p>
 <p><strong>Note</strong>: If installation stops due to billing account errors, set up the billing account and type: <code>sandboxctl create</code>.</p>
 <h3 id="next-steps">Next Steps</h3>
 <ul>

--- a/website/deploy/index.html
+++ b/website/deploy/index.html
@@ -59,7 +59,7 @@
       <h2>Get started now</h2>
       <div class="steps">
         <div class="step step-1">
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=develop&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:latest&cloudshell_tutorial=docs/tutorial.md"
+          <a class="console-btn" href="https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=develop&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:latest&cloudshell_tutorial=docs/tutorial.md"
              target="_blank">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -56,7 +56,7 @@
       <h2>Get started now</h2>
       <div class="steps">
         <div class="step step-1">
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=develop&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:latest&cloudshell_tutorial=docs/tutorial.md"
+          <a class="console-btn" href="https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=develop&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:latest&cloudshell_tutorial=docs/tutorial.md"
              target="_blank">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">


### PR DESCRIPTION
The cloud shell team changed their URL format to start with "shell" instead of "console". The old format is meant to still work, but there were some issues this week on their backend, so we should change over to the new format to be safe