### PR TITLE
chore: install kubectl extension

### DIFF
--- a/cloud-shell/Dockerfile
+++ b/cloud-shell/Dockerfile
@@ -20,6 +20,9 @@ RUN sudo apt-get install unzip && \
   unzip -o terraform.zip && \
   sudo install terraform /usr/local/bin
 
+# to fix kubectl authentication
+RUN apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+
 # install Postgres client and Json query
 RUN sudo apt-get -y install postgresql-client jq
 


### PR DESCRIPTION
kubectl authentication is changing in the latest gcloud builds. We need to install an extension in the custom cloud shell image to be able to reliably authenticate to our GKE clusters