### PR TITLE
fix: get_terraform_vars extra stdout output

### DIFF
--- a/terraform/get_terraform_vars.sh
+++ b/terraform/get_terraform_vars.sh
@@ -13,9 +13,9 @@
 # limitations under the License.
 #!/bin/bash
 
-project_id=$(gcloud config get-value project)
+project_id=$(gcloud config get-value project 2> /dev/null)
 zone=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project $project_id --format="value(zone)")
-gcloud container clusters get-credentials cloud-ops-sandbox --project $project_id --zone $zone
+gcloud container clusters get-credentials cloud-ops-sandbox --project $project_id --zone $zone > /dev/null 2> /dev/null
 
 # Retrieve the cluster's external IP
 TRIES=0


### PR DESCRIPTION
Sandbox deployments are currently failing due to unexpected output from the get_terraform_vars script.

It looks like gcloud was updated to be more verbose, writing extra text to stdout. Terraform expects this script to only print a JSON object, so I re-directed the output from gcloud commands