### PR TITLE
fix: Cloud Ops permission errors

### DIFF
--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -142,6 +142,43 @@ data "google_compute_default_service_account" "default" {
   ]
 }
 
+# Give service account Observability permissions
+resource "google_project_iam_member" "trace_role" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudtrace.admin"
+  member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+  depends_on = [data.google_compute_default_service_account.default]
+}
+
+resource "google_project_iam_member" "monitoring_role" {
+  project = data.google_project.project.project_id
+  role    = "roles/monitoring.editor"
+  member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+  depends_on = [data.google_compute_default_service_account.default]
+}
+
+
+resource "google_project_iam_member" "profiler_role" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudprofiler.agent"
+  member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+  depends_on = [data.google_compute_default_service_account.default]
+}
+
+resource "google_project_iam_member" "debugger_role" {
+  project = data.google_project.project.project_id
+  role    = "roles/clouddebugger.agent"
+  member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+  depends_on = [data.google_compute_default_service_account.default]
+}
+
+resource "google_project_iam_member" "logging_role" {
+  project = data.google_project.project.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+  depends_on = [data.google_compute_default_service_account.default]
+}
+
 # Create GSA/KSA binding: let IAM auth KSAs as a svc.id.goog member name
 resource "google_service_account_iam_binding" "set_gsa_binding" {
   service_account_id = data.google_compute_default_service_account.default.name // google_service_account.set_gsa.name

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -145,14 +145,14 @@ data "google_compute_default_service_account" "default" {
 # Give service account Observability permissions
 resource "google_project_iam_member" "trace_role" {
   project = data.google_project.project.project_id
-  role    = "roles/cloudtrace.admin"
+  role    = "roles/cloudtrace.agent"
   member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
   depends_on = [data.google_compute_default_service_account.default]
 }
 
 resource "google_project_iam_member" "monitoring_role" {
   project = data.google_project.project.project_id
-  role    = "roles/monitoring.editor"
+  role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
   depends_on = [data.google_compute_default_service_account.default]
 }


### PR DESCRIPTION
Over the last few weeks, we've been seeing missing data in the Cloud Ops products on new sandboxes. I thought this was due to our outdated version of Istio, but after some experimentation, it looks like it was due to incorrect permissions on the GKE cluster service account

This PR fixes the issue by adding extra roles to the default compute instance service account, ensuring GCP observability client libraries can send data to Cloud Ops