### PR TITLE
feat: simplify service dashboards

### DIFF
--- a/terraform/monitoring/03_services.tf
+++ b/terraform/monitoring/03_services.tf
@@ -12,81 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Define specifics for each of the services that will receive SLOs through a custom service
-# The data members needed are to specify the custom service, goals for each SLO (availability and latency),
-# and maximum error budget burn rates.
-variable "custom_services" {
-  type = list(object({
-    service_name           = string,
-    service_id             = string,
-    availability_goal      = number,
-    availability_burn_rate = number,
-    latency_goal           = number,
-    latency_threshold      = number,
-    latency_burn_rate      = number
-  }))
-  default = [
-    {
-      service_name           = "Frontend Service"
-      service_id             = "frontend"
-      availability_goal      = 0.9 # configurable goal for the availability SLO (0.9 = 90% of requests are successsful)
-      availability_burn_rate = 2   # limit on error budget burn rate (2 indicates we alert if error budget is consumed 2x faster than it should)
-      latency_goal           = 0.9 # configurable goal for the latency SLO (0.9 = 90% of requests finish in under the latency threshold)
-      latency_threshold      = 500 # indicates 500ms as the maximum latency of a 'good' request
-      latency_burn_rate      = 2
-    },
-    {
-      service_name           = "Checkout Service"
-      service_id             = "checkoutservice"
-      availability_goal      = 0.99
-      availability_burn_rate = 2
-      latency_goal           = 0.99
-      latency_threshold      = 500
-      latency_burn_rate      = 2
-    },
-    {
-      service_name           = "Payment Service"
-      service_id             = "paymentservice"
-      availability_goal      = 0.99
-      availability_burn_rate = 2
-      latency_goal           = 0.99
-      latency_threshold      = 500
-      latency_burn_rate      = 2
-    },
-    {
-      service_name           = "Email Service"
-      service_id             = "emailservice"
-      availability_goal      = 0.99
-      availability_burn_rate = 2
-      latency_goal           = 0.99
-      latency_threshold      = 500
-      latency_burn_rate      = 2
-    },
-    {
-      service_name           = "Shipping Service"
-      service_id             = "shippingservice"
-      availability_goal      = 0.99
-      availability_burn_rate = 2
-      latency_goal           = 0.99
-      latency_threshold      = 500
-      latency_burn_rate      = 2
-    }
-  ]
-}
-
-# Create a custom service that we attach our SLOs to
-# Using a custom service here allows us to add on additional SLOs and 
-# alerting policies on things such as custom metrics.
-#
-# There is the option to use an Istio service since Istio automatically detects and creates 
-# services for us. This example uses a custom service to demonstrate Terraform support for 
-# creating custom services with attached SLOs and alerting policies.
-resource "google_monitoring_custom_service" "custom_service" {
-  count        = length(var.custom_services)
-  service_id   = "${var.custom_services[count.index].service_id}-srv"
-  display_name = var.custom_services[count.index].service_name
-}
-
 # Specify services that will use the Istio service that is automatically detected
 # and created by installing Istio on the Kubernetes cluster.
 # The data members required are to successfully set up SLOs (goals and latency thresholds)
@@ -103,47 +28,92 @@ variable "istio_services" {
   }))
   default = [
     {
+      service_name           = "Frontend Service"
+      service_id             = "frontend"
+      availability_goal      = 0.9 # configurable goal for the availability SLO (0.9 = 90% of requests are successsful)
+      availability_burn_rate = 2   # limit on error budget burn rate (2 indicates we alert if error budget is consumed 2x faster than it should)
+      latency_goal           = 0.9 # configurable goal for the latency SLO (0.9 = 90% of requests finish in under the latency threshold)
+      latency_threshold      = 2000 # indicates 2000ms as the maximum latency of a 'good' request
+      latency_burn_rate      = 2
+    },
+    {
+      service_name           = "Checkout Service"
+      service_id             = "checkoutservice"
+      availability_goal      = 0.9
+      availability_burn_rate = 2
+      latency_goal           = 0.9
+      latency_threshold      = 1000
+      latency_burn_rate      = 2
+    },
+    {
+      service_name           = "Payment Service"
+      service_id             = "paymentservice"
+      availability_goal      = 0.9
+      availability_burn_rate = 2
+      latency_goal           = 0.9
+      latency_threshold      = 1000
+      latency_burn_rate      = 2
+    },
+    {
+      service_name           = "Email Service"
+      service_id             = "emailservice"
+      availability_goal      = 0.9
+      availability_burn_rate = 2
+      latency_goal           = 0.9
+      latency_threshold      = 1000
+      latency_burn_rate      = 2
+    },
+    {
+      service_name           = "Shipping Service"
+      service_id             = "shippingservice"
+      availability_goal      = 0.9
+      availability_burn_rate = 2
+      latency_goal           = 0.9
+      latency_threshold      = 1000
+      latency_burn_rate      = 2
+    },
+    {
       service_name           = "Cart Service"
       service_id             = "cartservice"
-      availability_goal      = 0.99
+      availability_goal      = 0.9
       availability_burn_rate = 2
-      latency_goal           = 0.99
-      latency_threshold      = 500
+      latency_goal           = 0.9
+      latency_threshold      = 1000
       latency_burn_rate      = 2
     },
     {
       service_name           = "Product Catalog Service"
       service_id             = "productcatalogservice"
-      availability_goal      = 0.99
+      availability_goal      = 0.9
       availability_burn_rate = 2
-      latency_goal           = 0.99
-      latency_threshold      = 500
+      latency_goal           = 0.9
+      latency_threshold      = 1000
       latency_burn_rate      = 2
     },
     {
       service_name           = "Currency Service"
       service_id             = "currencyservice"
-      availability_goal      = 0.99
+      availability_goal      = 0.9
       availability_burn_rate = 2
-      latency_goal           = 0.99
-      latency_threshold      = 500
+      latency_goal           = 0.9
+      latency_threshold      = 1000
       latency_burn_rate      = 2
     },
     {
       service_name           = "Recommendation Service"
       service_id             = "recommendationservice"
-      availability_goal      = 0.99
+      availability_goal      = 0.8
       availability_burn_rate = 2
-      latency_goal           = 0.99
-      latency_threshold      = 500
+      latency_goal           = 0.9
+      latency_threshold      = 1000
       latency_burn_rate      = 2
     },
     {
       service_name           = "Ad Service"
       service_id             = "adservice"
-      availability_goal      = 0.99
+      availability_goal      = 0.9
       availability_burn_rate = 2
-      latency_goal           = 0.99
+      latency_goal           = 0.9
       latency_threshold      = 500
       latency_burn_rate      = 2
     }

--- a/terraform/monitoring/04_slos.tf
+++ b/terraform/monitoring/04_slos.tf
@@ -12,88 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Create an SLO for availability for the custom service.
-# For all services other than Frontend SLO is defined as following:
-#   99% of HTTP requests are successful within the past 30 day windowed period
-# For the Frontend service SLO is defined as following:
-#   90% of HTTP requests are successful within the past 30 day windowed period
-
-resource "google_monitoring_slo" "custom_service_availability_slo" {
-  count        = length(var.custom_services)
-  service      = google_monitoring_custom_service.custom_service[count.index].service_id
-  slo_id       = "${google_monitoring_custom_service.custom_service[count.index].service_id}-availability-slo"
-  display_name = "Availability SLO with request base SLI (good total ratio) for ${google_monitoring_custom_service.custom_service[count.index].service_id}"
-
-  # The goal sets our objective for successful requests over the 30 day rolling window period
-  goal                = var.custom_services[count.index].availability_goal
-  rolling_period_days = 30
-
-  request_based_sli {
-    good_total_ratio {
-
-      # The "good" service is the number of 200 OK responses
-      good_service_filter = join(" AND ", [
-        "metric.type=\"istio.io/service/server/request_count\"",
-        "resource.type=\"k8s_container\"",
-        "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
-        "metadata.user_labels.\"app\"=\"${var.custom_services[count.index].service_id}\"",
-        "metric.label.\"response_code\"=\"200\""
-      ])
-
-      # The total is the number of non-4XX responses
-      # We eliminate 4XX responses since they do not accurately represent server-side 
-      # failures and have the possibility of skewing our SLO measurements
-      total_service_filter = join(" AND ", [
-        "metric.type=\"istio.io/service/server/request_count\"",
-        "resource.type=\"k8s_container\"",
-        "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
-        "metadata.user_labels.\"app\"=\"${var.custom_services[count.index].service_id}\"",
-        join(" OR ", ["metric.label.\"response_code\"<\"400\"",
-        "metric.label.\"response_code\">=\"500\""])
-      ])
-
-    }
-  }
-}
-
-# Create another SLO on the custom service this time with respect to latency.
-# For all services other than Frontend SLO is defined as following:
-#   99% of requests return in under 500 ms in the previous 30 days
-# For the Frontend service SLO is defined as following:
-#   90% of requests return in under 500 ms in the previous 30 days
-resource "google_monitoring_slo" "custom_service_latency_slo" {
-  count        = length(var.custom_services)
-  service      = google_monitoring_custom_service.custom_service[count.index].service_id
-  slo_id       = "${google_monitoring_custom_service.custom_service[count.index].service_id}-latency-slo"
-  display_name = "Latency SLO with request base SLI (distribution cut) for ${google_monitoring_custom_service.custom_service[count.index].service_id}"
-
-  goal                = var.custom_services[count.index].latency_goal
-  rolling_period_days = 30
-
-  request_based_sli {
-    distribution_cut {
-
-      # The distribution filter retrieves latencies of requests that returned 200 OK responses
-      distribution_filter = join(" AND ", [
-        "metric.type=\"istio.io/service/server/response_latencies\"",
-        "resource.type=\"k8s_container\"",
-        "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
-        "metric.label.\"response_code\"=\"200\"",
-        "metadata.user_labels.\"app\"=\"${var.custom_services[count.index].service_id}\""
-      ])
-
-      range {
-
-        # By not setting a min value, it is automatically set to -infinity
-        # The units of the upper bound is in ms
-        max = var.custom_services[count.index].latency_threshold
-
-      }
-    }
-  }
-}
-
-# Create an SLO for availability for the Istio service.
+# Create an SLO for availability for the Istio services.
 # Example SLO is defined as following:
 #   90% of HTTP requests are successful within the past 30 day windowed period
 resource "google_monitoring_slo" "istio_service_availability_slo" {
@@ -102,39 +21,20 @@ resource "google_monitoring_slo" "istio_service_availability_slo" {
   count        = length(var.istio_services)
   service      = "ist:${var.project_id}-zone-${var.zone}-cloud-ops-sandbox-default-${var.istio_services[count.index].service_id}"
   slo_id       = "${var.istio_services[count.index].service_id}-availability-slo"
-  display_name = "Availability SLO with request base SLI (good total ratio) for ${var.istio_services[count.index].service_id}"
+  display_name = "${var.istio_services[count.index].availability_goal * 100}% - Availability - Rolling 30 Days - ${var.istio_services[count.index].service_id}"
 
   # The goal sets our objective for successful requests over the 30 day rolling window period
   goal                = var.istio_services[count.index].availability_goal
   rolling_period_days = 30
 
-  request_based_sli {
-    good_total_ratio {
-
-      # The "good" service is the number of 200 OK responses
-      good_service_filter = join(" AND ", [
-        "metric.type=\"istio.io/service/server/request_count\"",
-        "resource.type=\"k8s_container\"",
-        "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
-        "metadata.user_labels.\"app\"=\"${var.istio_services[count.index].service_id}\"",
-        "metric.label.\"response_code\"=\"200\""
-      ])
-
-      # The total is the number of non-4XX responses
-      # We eliminate 4XX responses since they do not accurately represent server-side 
-      # failures and have the possibility of skewing our SLO measurements
-      total_service_filter = join(" AND ", [
-        "metric.type=\"istio.io/service/server/request_count\"",
-        "resource.type=\"k8s_container\"",
-        "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
-        "metadata.user_labels.\"app\"=\"${var.istio_services[count.index].service_id}\"",
-        join(" OR ", ["metric.label.\"response_code\"<\"400\"",
-        "metric.label.\"response_code\">=\"500\""])
-      ])
-
+  basic_sli {
+    availability {
+      enabled = "true"
     }
   }
 }
+
+
 
 # Create an SLO with respect to latency using the Istio service.
 # Example SLO is defined as:
@@ -143,7 +43,7 @@ resource "google_monitoring_slo" "istio_service_latency_slo" {
   count               = length(var.istio_services)
   service             = "ist:${var.project_id}-zone-${var.zone}-cloud-ops-sandbox-default-${var.istio_services[count.index].service_id}"
   slo_id              = "${var.istio_services[count.index].service_id}-latency-slo"
-  display_name        = "Latency SLO with request base SLI (distribution cut) for ${var.istio_services[count.index].service_id}"
+  display_name        = "${var.istio_services[count.index].availability_goal * 100}% - Latency - Rolling 30 days - ${var.istio_services[count.index].service_id}"
   goal                = var.istio_services[count.index].latency_goal
   rolling_period_days = 30
 
@@ -170,7 +70,7 @@ resource "google_monitoring_slo" "istio_service_latency_slo" {
 }
 
 # Rating service availability SLO:
-#   99% of HTTP requests are successful within the past 30 day windowed period
+#   90% of HTTP requests are successful within the past 30 day windowed period
 
 resource "google_monitoring_slo" "rating_service_availability_slo" {
   # Uses ratingservice service that is automatically detected and created when the service is deployed to App Engine
@@ -181,7 +81,7 @@ resource "google_monitoring_slo" "rating_service_availability_slo" {
   display_name = "Rating Service Availability SLO with request base SLI (good total ratio)"
 
   # The goal sets our objective for successful requests over the 30 day rolling window period
-  goal                = 0.99
+  goal                = 0.9
   rolling_period_days = 30
 
   request_based_sli {
@@ -218,7 +118,7 @@ resource "google_monitoring_slo" "rating_service_availability_slo" {
 }
 
 # Rating service latency SLO:
-#   99% of requests that return in under 175 ms in the previous 30 days
+#   90% of requests that return in under 175 ms in the previous 30 days
 
 resource "google_monitoring_slo" "rating_service_latency_slo" {
   # Uses ratingservice service that is automatically detected and created when the service is deployed to App Engine
@@ -228,7 +128,7 @@ resource "google_monitoring_slo" "rating_service_latency_slo" {
   slo_id       = "ratingservice-latency-slo"
   display_name = "Rating Service Latency SLO with request base SLI (distribution cut)"
 
-  goal                = 0.99
+  goal                = 0.9
   rolling_period_days = 30
 
   request_based_sli {
@@ -247,7 +147,7 @@ resource "google_monitoring_slo" "rating_service_latency_slo" {
       range {
         # By not setting a min value, it is automatically set to -infinity
         # The upper bound for latency is in ms
-        max = 500
+        max = 1000
       }
     }
   }
@@ -263,7 +163,7 @@ resource "google_monitoring_slo" "rating_service_freshness_slo" {
   slo_id       = "ratingservice-freshness-slo"
   display_name = "Rating freshness SLO with window based SLI"
 
-  goal                = 0.99
+  goal                = 0.9
   rolling_period_days = 1
 
   windows_based_sli {

--- a/terraform/monitoring/05_alerting_policies.tf
+++ b/terraform/monitoring/05_alerting_policies.tf
@@ -12,56 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Create an alerting policy on the Availability SLO for the custom service.
-# The definition of the SLO can be found in the file '03_service_slo.tf'.
-# We alert on budget burn rate, alerting if burn rate exceeds the threshold defined for the service
-resource "google_monitoring_alert_policy" "custom_service_availability_slo_alert" {
-  count        = length(var.custom_services)
-  display_name = "${var.custom_services[count.index].service_name} Availability Alert Policy"
-  combiner     = "AND"
-  conditions {
-    display_name = "SLO burn rate alert for availability SLO with a threshold of ${var.custom_services[count.index].availability_burn_rate}"
-    condition_threshold {
-
-      # This filter alerts on burn rate over the past 60 minutes
-      filter = "select_slo_burn_rate(\"projects/${var.project_id}/services/${google_monitoring_custom_service.custom_service[count.index].service_id}/serviceLevelObjectives/${google_monitoring_slo.custom_service_availability_slo[count.index].slo_id}\", 60m)"
-
-      # The threshhold is determined by how quickly we burn through our error budget.
-      # Example: if threshold_value = 2 then error budget is consumed in 15 days.
-      # Details: https://landing.google.com/sre/workbook/chapters/alerting-on-slos/#4-alert-on-burn-rate 
-      threshold_value = var.custom_services[count.index].availability_burn_rate
-      comparison      = "COMPARISON_GT"
-      duration        = "60s"
-    }
-  }
-  documentation {
-    content   = "Availability SLO burn for the ${var.custom_services[count.index].service_name} for the past 60m exceeded ${var.custom_services[count.index].availability_burn_rate}x the acceptable budget burn rate. The service is returning less OK responses than desired. Consider viewing the service logs or custom dashboard to retrieve more information or adjust the values for the SLO and error budget."
-    mime_type = "text/markdown"
-  }
-}
-
-# Create another alerting policy, this time on the SLO for latency for the custom service.
-# Alert on budget burn rate as well.
-resource "google_monitoring_alert_policy" "custom_service_latency_slo_alert" {
-  count        = length(var.custom_services)
-  display_name = "${var.custom_services[count.index].service_name} Latency Alert Policy"
-  combiner     = "AND"
-  conditions {
-    display_name = "SLO burn rate alert for latency SLO with a threshold of ${var.custom_services[count.index].latency_burn_rate}"
-    condition_threshold {
-      filter          = "select_slo_burn_rate(\"projects/${var.project_id}/services/${google_monitoring_custom_service.custom_service[count.index].service_id}/serviceLevelObjectives/${google_monitoring_slo.custom_service_latency_slo[count.index].slo_id}\", 60m)"
-      threshold_value = var.custom_services[count.index].availability_burn_rate
-      comparison      = "COMPARISON_GT"
-      duration        = "60s"
-    }
-  }
-  documentation {
-    content   = "Latency SLO burn for the ${var.custom_services[count.index].service_name} for the past 60m exceeded ${var.custom_services[count.index].latency_burn_rate}x the acceptable budget burn rate. The service is responding slower than desired. Consider viewing the service logs or custom dashboard to retrieve more information or adjust the values for the SLO and error budget."
-    mime_type = "text/markdown"
-  }
-}
-
-# Create an alerting policy on the Availability SLO for the Istio service.
+# Create an alerting policy on the Availability SLO for the Istio services.
 # The definition of the SLO can be found in the file '04_slos.tf'.
 # Alerts on error budget burn rate.
 resource "google_monitoring_alert_policy" "istio_service_availability_slo_alert" {


### PR DESCRIPTION
- Previously, terraform was setting up duplicate dashboards; some created by istio, and some created manually. This PR removes the custom ones, so the Cloud Monitoring interface is easier to read
- I also loosened some of the SLO definitions. Currently they would instantly fail and send out alerts. We would prefer a fresh sandbox to be within its SLO budget