### PR TITLE
fix: Enable staleness and pull request size bots on the repo 

### DIFF
--- a/.github/auto-label.yaml
+++ b/.github/auto-label.yaml
@@ -47,3 +47,9 @@ language:
     website:
       .: 'javascript'
       images: 'svg'
+requestsize:
+  enabled: true
+staleness:
+  pullrequest: true
+  old: 30
+  extraold: 60


### PR DESCRIPTION
Replaces https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/pull/922

Enable staleness and pull request size bots on the repo