### PR TITLE
fix: enabled cloud sql admin api

### DIFF
--- a/terraform/02_project.tf
+++ b/terraform/02_project.tf
@@ -101,6 +101,15 @@ resource "google_project_service" "mesh" {
   disable_dependent_services = true
 }
 
+resource "google_project_service" "sqladmin" {
+  project = data.google_project.project.project_id
+
+  service = "sqladmin.googleapis.com"
+
+  disable_dependent_services = true
+}
+
+
 # Enable GKE in the project we created. If you look at the docs you might see
 # the `google_project_services` resource which allows you to specify a list of
 # resources to enable. This seems like a good idea but there's a gotcha: to use


### PR DESCRIPTION
The ratingservice was failing to connect to Cloud SQL due to an unenabled API. This PR enables the API as part of terraform deployment