### PR TITLE
fix: Enable the cloud-sql-proxy path to Cloud SQL for ratingservice

### DIFF
--- a/terraform/ratingservice/01_project.tf
+++ b/terraform/ratingservice/01_project.tf
@@ -31,3 +31,10 @@ resource "google_project_service" "cloudbuild" {
   disable_dependent_services = true
   project                    = var.gcp_project_id
 }
+
+resource "google_project_service" "sqladmin" {
+  service                    = "sqladmin.googleapis.com"
+  disable_dependent_services = true
+  project                    = var.gcp_project_id
+}
+


### PR DESCRIPTION
Enable the Cloud SQL Admin API and add Cloud SQL Client role for the
App Engine service account. 
See https://cloud.google.com/sql/docs/mysql/connect-app-engine-standard for more background.