### PR TITLE
chore: test adjustments

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -145,6 +145,7 @@ jobs:
           PULL_REQUEST_TITLE: "chore: release/${{ github.event.inputs.version  }}"
           PULL_REQUEST_BRANCH: "main"
   push-release-containers:
+    needs: make-release
     runs-on: [self-hosted, push-privilege]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/update-custom-image.yml
+++ b/.github/workflows/update-custom-image.yml
@@ -26,7 +26,7 @@ on:
     tags:
       - 'v*'
   workflow_run:
-    workflows: ["Make Release"]
+    workflows: [Make Release]
     types:
       - completed
   workflow_dispatch:

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -25,6 +25,7 @@ cd $SCRIPT_DIR
 
 # set environment variables
 export PROJECT_ID=$(gcloud config get-value project)
+export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format="value(projectNumber)")
 export ZONE=$(gcloud container clusters list --filter="name:cloud-ops-sandbox" --project ${PROJECT_ID} --format="value(zone)")
 export LOADGEN_ZONE=$(gcloud container clusters list --filter="name:loadgenerator" --project ${PROJECT_ID} --format="value(zone)")
 
@@ -33,7 +34,7 @@ echo "running monitoring integration tests.."
 python3 -m venv --system-site-packages monitor-venv
 source monitor-venv/bin/activate
 python3 -m pip install -r $SCRIPT_DIR/requirements.txt
-python3 $SCRIPT_DIR/monitoring_integration_test.py ${PROJECT_ID}
+python3 $SCRIPT_DIR/monitoring_integration_test.py ${PROJECT_ID} ${PROJECT_NUMBER}
 deactivate
 
 # run provisioning test
@@ -49,12 +50,14 @@ deactivate
 # run rating service tests
 if [[ -z "$SKIP_RATINGS_TEST" ]]; then
   echo "running ratingservice tests.."
+  pushd $SCRIPT_DIR/..
   RATING_SERVICE_URL="https://ratingservice-dot-$(gcloud app describe --format='value(defaultHostname)' --project=${PROJECT_ID})"
   python3 -m venv --system-site-packages ratings-venv
   source ratings-venv/bin/activate
   python3 -m pip install -r $SCRIPT_DIR/ratingservice/requirements.txt
-  python3 $SCRIPT_DIR/ratingservice/main_test.py
+  python3 $SCRIPT_DIR/ratingservice/main_test.py $RATING_SERVICE_URL
   deactivate
+  popd
 else
   echo "rating test skipped"
 fi


### PR DESCRIPTION
- We recently added `sandboxctl test` to run tests against a live sandbox environment, but it wasn't working for the ratingservice tests. This fixes that
- added a dependency to the make-release release pipeline, so it will run steps in sequence instead of parallel (https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/943)
- removed quotes from workflow custom image trigger, since the trigger wasn't firing and removing quotes seems to be better in line with the spec