### PR TITLE
chore: release/v0.8.1

### DIFF
--- a/PR.txt
+++ b/PR.txt
@@ -1,0 +1,1 @@
+## [v0.8.1](https://www.github.com/cloud-ops-sandbox/compare/bbfa79ebf3fae57c8b4517c0813cb9370c169b60...bbfa79ebf3fae57c8b4517c0813cb9370c169b60)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 
 Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
 
-[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.8.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.8.0&cloudshell_tutorial=docs/tutorial.md)
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.8.1&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.8.1&cloudshell_tutorial=docs/tutorial.md)
 
 __Note__: If installation stops due to billing account errors, set up the billing account and type: `sandboxctl create`.
 

--- a/cloud-shell/Dockerfile
+++ b/cloud-shell/Dockerfile
@@ -37,7 +37,7 @@ RUN python3 -m pip install click==8.0.1
 RUN python3 -m pip install google-cloud-monitoring==2.4.0
 
 # set env var
-RUN echo "VERSION=v0.8.0" >> /etc/environment
+RUN echo "VERSION=v0.8.1" >> /etc/environment
 
 # Change "Open in Cloudshell" script to run `sandboxctl create` using local file and changing it
 COPY cloudshell_open_cp.sh /google/devshell/bashrc.google.d/cloudshell_open.sh

--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: adservice
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/adservice:v0.8.0
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/adservice:v0.8.1
         ports:
         - containerPort: 9555
         env:

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -32,7 +32,7 @@ spec:
           command: ['bin/sh', '-c', 'until nslookup redis-cart; do echo waiting for redis; sleep 2; done;']
       containers:
       - name: cartservice
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/cartservice:v0.8.0
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/cartservice:v0.8.1
         ports:
         - containerPort: 7070
         env:

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: checkoutservice
-          image: gcr.io/stackdriver-sandbox-230822/sandbox/checkoutservice:v0.8.0
+          image: gcr.io/stackdriver-sandbox-230822/sandbox/checkoutservice:v0.8.1
           ports:
           - containerPort: 5050
           readinessProbe:

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: currencyservice
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/currencyservice:v0.8.0
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/currencyservice:v0.8.1
         ports:
         - name: grpc
           containerPort: 7000

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: emailservice
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/emailservice:v0.8.0
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/emailservice:v0.8.1
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: frontend
-          image: gcr.io/stackdriver-sandbox-230822/sandbox/frontend:v0.8.0
+          image: gcr.io/stackdriver-sandbox-230822/sandbox/frontend:v0.8.1
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: paymentservice
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/paymentservice:v0.8.0
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/paymentservice:v0.8.1
         ports:
         - containerPort: 50051
         readinessProbe:

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: productcatalogservice
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/productcatalogservice:v0.8.0
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/productcatalogservice:v0.8.1
         ports:
         - containerPort: 3550
         readinessProbe:

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: recommendationservice
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/recommendationservice:v0.8.0
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/recommendationservice:v0.8.1
         ports:
         - containerPort: 8080
         env:

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: shippingservice
-        image: gcr.io/stackdriver-sandbox-230822/sandbox/shippingservice:v0.8.0
+        image: gcr.io/stackdriver-sandbox-230822/sandbox/shippingservice:v0.8.1
         ports:
         - containerPort: 50051
         readinessProbe:

--- a/loadgenerator-manifests/loadgenerator.yaml
+++ b/loadgenerator-manifests/loadgenerator.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: locust-main
-          image: gcr.io/stackdriver-sandbox-230822/sandbox/loadgenerator/gke:v0.8.0
+          image: gcr.io/stackdriver-sandbox-230822/sandbox/loadgenerator/gke:v0.8.1
           imagePullPolicy: Always
           env:
             - name: LOCUST_MODE

--- a/sre-recipes/sandboxctl
+++ b/sre-recipes/sandboxctl
@@ -179,13 +179,13 @@ def describe():
     gcp_path = "https://console.cloud.google.com"
     project_id, err = utils.get_project_id()
     if err:
-        print("Failed to get project ID:". err)
+        print("Failed to get project ID:", err)
     external_ip, err = utils.get_external_ip()
     if err:
-        print("Failed to get external ID:". err)
+        print("Failed to get external ID:", err)
     loadgen_ip, err = utils.get_loadgen_ip()
     if err:
-        print("Failed to get loadgen ID:". err)
+        print("Failed to get loadgen ID:", err)
     gcp_kubernetes_path = gcp_path + '/kubernetes/workload?project=' + project_id
     gcp_monitoring_path = gcp_path + '/monitoring?project=' + project_id
     print(f"""Cloud Operations Sandbox info for project: {project_id}

--- a/website/config.toml
+++ b/website/config.toml
@@ -96,7 +96,7 @@ archived_version = false
 # The version number for the version of the docs represented in this doc set.
 # Used in the "version-banner" partial to display a version number for the 
 # current doc set.
-version = "v0.8.0"
+version = "v0.8.1"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.

--- a/website/deploy/docs/_print/index.html
+++ b/website/deploy/docs/_print/index.html
@@ -412,7 +412,7 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 </ul>
 <h3 id="set-up">Set Up</h3>
 <p>Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.</p>
-<p><a href="https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&amp;cloudshell_git_branch=v0.7.5&amp;shellonly=true&amp;cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.8.0&amp;cloudshell_tutorial=docs/tutorial.md"><img src="http://www.gstatic.com/cloudssh/images/open-btn.svg" alt="Open in Cloud Shell"></a></p>
+<p><a href="https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&amp;cloudshell_git_branch=v0.7.5&amp;shellonly=true&amp;cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.8.1&amp;cloudshell_tutorial=docs/tutorial.md"><img src="http://www.gstatic.com/cloudssh/images/open-btn.svg" alt="Open in Cloud Shell"></a></p>
 <p><strong>Note</strong>: If installation stops due to billing account errors, set up the billing account and type: <code>sandboxctl create</code>.</p>
 <h3 id="next-steps">Next Steps</h3>
 <ul>

--- a/website/deploy/docs/getting_started/index.html
+++ b/website/deploy/docs/getting_started/index.html
@@ -509,7 +509,7 @@ if (!doNotTrack) {
 </ul>
 <h3 id="set-up">Set Up</h3>
 <p>Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.</p>
-<p><a href="https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&amp;cloudshell_git_branch=v0.7.5&amp;shellonly=true&amp;cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.8.0&amp;cloudshell_tutorial=docs/tutorial.md"><img src="http://www.gstatic.com/cloudssh/images/open-btn.svg" alt="Open in Cloud Shell"></a></p>
+<p><a href="https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&amp;cloudshell_git_branch=v0.7.5&amp;shellonly=true&amp;cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.8.1&amp;cloudshell_tutorial=docs/tutorial.md"><img src="http://www.gstatic.com/cloudssh/images/open-btn.svg" alt="Open in Cloud Shell"></a></p>
 <p><strong>Note</strong>: If installation stops due to billing account errors, set up the billing account and type: <code>sandboxctl create</code>.</p>
 <h3 id="next-steps">Next Steps</h3>
 <ul>

--- a/website/deploy/index.html
+++ b/website/deploy/index.html
@@ -60,7 +60,7 @@
       <div class="steps">
         <div class="step step-1">
           
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.8.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.8.0&cloudshell_tutorial=docs/tutorial.md"
+          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.8.1&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.8.1&cloudshell_tutorial=docs/tutorial.md"
              target="_blank">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
@@ -79,7 +79,7 @@
 
   <footer>
     <p class="fineprint">* Note: This is <b>NOT</b> an official Google product. Customers will be billed for using cloud resources when creating a sandbox cluster. 
-    <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': 'v0.8.0' });">Submit Feedback</button>
+    <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': 'v0.8.1' });">Submit Feedback</button>
       </p>
   </footer>
 </body>

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -56,7 +56,7 @@
       <h2>Get started now</h2>
       <div class="steps">
         <div class="step step-1">
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.8.0&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.8.0&cloudshell_tutorial=docs/tutorial.md"
+          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-ops-sandbox.git&cloudshell_git_branch=v0.8.1&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image/uncertified:v0.8.1&cloudshell_tutorial=docs/tutorial.md"
              target="_blank">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
@@ -75,7 +75,7 @@
 
   <footer>
     <p class="fineprint">* Note: This is <b>NOT</b> an official Google product. Customers will be billed for using cloud resources when creating a sandbox cluster.
-      <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': 'v0.8.0' });">Submit Feedback</button>
+      <button onclick="userfeedback.api.startFeedback({ 'productId': '5235454', 'productVersion': 'v0.8.1' });">Submit Feedback</button>
     </p>
   </footer>
 </body>


### PR DESCRIPTION
# [v0.8.1](https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/compare/25998916bd8d8b3e48280dcc5e19e3587ed986d8...82cd6135c317f241402c73b982d0c3a0090c0e1e)
 
### Features
- feat: upgrade Istio 1.7.1 to ASM (#930)
- feat: simplify service dashboards (#933)
- feat: add flag to skip ratingservice deployment (#923)
 
### Bug Fixes
- chore: pin terraform provider version
- fix: error handling message in sandboxctl describe
- chore: Remove dependency dashboard
- fix: Enable the cloud-sql-proxy path to Cloud SQL for ratingservice (#945)
- fix: github actions fix container build on release (#941)
- fix: don't raise error for warning logs (#940)
- fix: Cloud Ops permission errors (#931)
- fix: Enable staleness and pull request size bots on the repo (#934)
 
### Documentation
- docs: add missing user-guide images
- docs: remove $ from shell commands
 
### Miscellaneous
- chore: Update CODEOWNERS
- chore: pin terraform provider version
- chore: Remove dependency dashboard
- chore: test adjustments (#946)
- chore(tests): Add cloud ops data tests (#932)
- chore: lock file maintenance (#787)
- chore: updated frontend go version (#938)