### PR TITLE
fix(releases): release notes show commits in title

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -95,7 +95,7 @@ jobs:
 
           # print version number as title
           export NEW_VERSION=${{ github.event.inputs.version  }}
-          echo "## [$NEW_VERSION](https://www.github.com/${{ github.repository }}/compare/$LAST_HASH...$FIRST_HASH)" > PR.txt
+          echo "## [$NEW_VERSION](https://www.github.com/${{ github.repository }}/compare/$PREV_HASH...$RECENT_HASH)" > PR.txt
 
           # build category buckets
           # format: title/prefix|prefix|prefix...


### PR DESCRIPTION
I noticed a but in the release notes section of the `make-release` action. The names of the hashes in the URL didn't match the names of the environment variables set earlier. This would result in broken links in the PR description