### PR TITLE
fix: resolve cartservice initialization

### DIFF
--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 5
       initContainers:
         - name: init-redis-ready
-          image: busybox
+          image: busybox:1.28
           command: ['bin/sh', '-c', 'until nslookup redis-cart; do echo waiting for redis; sleep 2; done;']
       containers:
       - name: cartservice


### PR DESCRIPTION
Pin the version of busybox image in init-redis-ready container of the cartservice
to the version 1.28 that does not have a problem with nslookup

Fixes #995