### PR TITLE
fix: fix incorrect instructions and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ project ID:
 
 ```bash
 git clone https://github.com/GoogleCloudPlatform/cloud-ops-sandbox
-gcloud auth application-default loging
+gcloud auth application-default login
 cloud-ops-sandbox/provisioning/sandboxctl create -p PROJECT_ID
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,10 +46,10 @@ instructions:
 
 Or, by executing the following commands in your local environment:
 
-```terminal
+```shell
 git clone https://github.com/GoogleCloudPlatform/cloud-ops-sandbox
-gcloud auth application-default loging
-cloud-ops-sandbox/provisioning/sandboxctl -p PROJECT_ID
+gcloud auth application-default login
+cloud-ops-sandbox/provisioning/sandboxctl create -p PROJECT_ID
 ```
 
 where `PROJECT_ID` identifies the Google Cloud project where you want to

--- a/provisioning/sandboxctl
+++ b/provisioning/sandboxctl
@@ -211,7 +211,7 @@ fatal_with_usage() {
 }
 
 version_message() {
-  echo "${VERSION}"
+  echo "${SANDBOX_VERSION}"
 }
 
 usage() {
@@ -416,7 +416,6 @@ local_iam_user() {
 
 prepare_terraform_state() {
   TF_BUCKET_NAME="${PROJECT_ID}-cloud-ops-sandbox-tf-state"
-  local URIS
   NAMES=$(gcloud storage buckets list "gs://${TF_BUCKET_NAME}*" --format="value(name)" --project "${PROJECT_ID}")
   if [[ -z "${NAMES}" ]]; then
     info "Creating storage bucket to host Cloud Ops Sandbox state..."
@@ -437,7 +436,6 @@ does_terraform_state_exist() {
   else
     STATE_OBJ_URI="gs://${TF_BUCKET_NAME}/${TERRAFORM_PREFIX}/default.tfstate"
   fi
-  local URIS
   NAMES=$(gcloud storage objects list "${STATE_OBJ_URI}" --format="value(name)" --project "${PROJECT_ID}")
   if [[ -z "${NAMES}" ]]; then
     false


### PR DESCRIPTION
Replace `loging` with `login` in the tutorial and README(s).
Use correct variable (`SANDBOX_VERSION` instead of undefined `VERSION`) to print version in `sandboxctl -version` CLI.
Add missing `create` command in README docs.

🛠️ Fixes #1047, Fixes #1045
