### PR TITLE
fix: Fix root README badges to use the main branch' results

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -14,6 +14,9 @@
 name: CLI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [opened,synchronize,reopened]
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -14,6 +14,9 @@
 name: Terraform
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [opened,synchronize,reopened]
     paths:

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ under Apache 2.0. Full license text is available in [LICENSE](LICENSE).
 > This is not an official Google project. Please, report any issues or feature requests related to this project [here].
 
 [1]: https://console.cloud.google.com/?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fgooglecloudplatform%2Fcloud-ops-sandbox&cloudshell_git_branch=0.9.2&cloudshell_tutorial=docs/walkthrough.md
-[tf_badge]: https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/actions/workflows/terraform.yaml/badge.svg
-[cli_badge]: https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/actions/workflows/cli.yaml/badge.svg
+[tf_badge]: https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/actions/workflows/terraform.yaml/badge.svg?branch=main
+[cli_badge]: https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/actions/workflows/cli.yaml/badge.svg?branch=main
 [cloud-ops]: (https://cloud.google.com/products/operations)
 [ob]: https://github.com/GoogleCloudPlatform/microservices-demo
 [gke]: https://cloud.google.com/kubernetes-engine


### PR DESCRIPTION
This PR fixes https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/issues/1051:
- Makes sure that the CLI and Terraform workflows run on the main branch instead of just in PRs
- Makes sure that the root README Action badges only uses the results taken from latest main commit, rather than "whichever last PR was opened / had the workflows run" which leads to a mismatch between what users think the badges mean (latest commit) and what the badges used to do (latest PR, regardless if it was even merged)